### PR TITLE
Add instumentation feature flag

### DIFF
--- a/hermit-sys/Cargo.toml
+++ b/hermit-sys/Cargo.toml
@@ -13,7 +13,7 @@ build = "build.rs"
 
 [features]
 # controlls whether RustyHermit is build with -Z instrument-mcount
-instrument = []
+instrument = ["rftrace"]
 
 [dependencies]
 log = { version = "0.4", default-features = false }
@@ -28,3 +28,8 @@ version = "0.6.0"
 optional = true
 default-features = false
 features = ["log", "verbose", "std", "ethernet", "socket-udp", "socket-tcp", "proto-ipv4", "proto-ipv6"]
+
+[dependencies.rftrace]
+optional = true
+features = ["backend", "buildstd", "hermit"]
+git = "https://github.com/tlambertz/rftrace"

--- a/hermit-sys/Cargo.toml
+++ b/hermit-sys/Cargo.toml
@@ -11,6 +11,10 @@ categories = ["os"]
 links = "hermit"
 build = "build.rs"
 
+[features]
+# controlls whether RustyHermit is build with -Z instrument-mcount
+instrument = []
+
 [dependencies]
 log = { version = "0.4", default-features = false }
 lazy_static = "1.4.0"


### PR DESCRIPTION
This pull request adds a `instrument` feature flag to hermit-sys, which when enabled:
- compiles libhermit-rs, core, alloc, with `-Z instrument-mcount`
- enables the optional dependency [rftrace](https://github.com/tlambertz/rftrace) so the build does not fail because mcount() symbol is missing.

See rftrace readme for details on how to setup the frontend to enable the gathering of events and saving them to disk.

What branch do you want this pull/future request on? I see both devel an master are getting updated regularly?