### PR TITLE
build.rs: Fail fast on errors when building libhermit-rs

### DIFF
--- a/hermit-sys/build.rs
+++ b/hermit-sys/build.rs
@@ -32,7 +32,13 @@ fn build() {
 			.replace("-Z instrument-mcount", ""),
 	);
 
-	cmd.output().expect("Unable to build kernel");
+	let output = cmd.output().expect("Unable to build kernel");
+	let stdout = std::string::String::from_utf8(output.stdout);
+	let stderr = std::string::String::from_utf8(output.stderr);
+	println!("Build libhermit-rs output-status: {}", output.status);
+	println!("Build libhermit-rs output-stdout: {}", stdout.unwrap());
+	println!("Build libhermit-rs output-stderr: {}", stderr.unwrap());
+	assert!(output.status.success());
 
 	println!(
 		"cargo:rustc-link-search=native={}/target/x86_64-unknown-hermit-kernel/{}",


### PR DESCRIPTION
Previously failure of the build command in hermit-sys/build.rs would not lead to immediate failure. The build would only fail in the last step, when the hermit library can't be found. This PR fixes this.
Changes:
- Asserts that the output status of the build command is "success"
- Prints the output of the build command so that it can be viewed when building with -vv or if the build command was not successful.