### PR TITLE
Fix #7 by using older version of rust nightly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,18 +18,18 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [nightly]
+        rust: [nightly-2020-04-29]
         include:
           - os: macOS-latest
-            rust: 'nightly'
+            rust: 'nightly-2020-04-29'
             components: 'rust-src'
             targets: 'x86_64-apple-darwin'
           - os: windows-latest
-            rust: 'nightly'
+            rust: 'nightly-2020-04-29'
             components: 'rust-src'
             targets: 'x86_64-pc-windows-msvc'
           - os: ubuntu-latest
-            rust: 'nightly'
+            rust: 'nightly-2020-04-29'
             components: 'rust-src'
             targets: 'x86_64-unknown-linux-gnu'
 
@@ -46,6 +46,8 @@ jobs:
       run: cargo --version
     - name: Install cargo-download
       run: cargo install cargo-download
+    - name: Set override for Rust version
+      run: rustup override set ${{ matrix.rust }}
     - name: Building dev version
       run:
          cargo build -Z build-std=std,core,alloc,panic_abort --target x86_64-unknown-hermit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        rust: [nightly]
+        rust: [nightly-2020-04-29]
         include:
           - os: ubuntu-latest
-            rust: 'nightly'
+            rust: 'nightly-2020-04-29'
             components: 'rust-src, llvm-tools-preview'
             targets: 'x86_64-unknown-linux-gnu'
 
@@ -43,6 +43,10 @@ jobs:
       run: cargo install cargo-xbuild
     - name: Install qemu/nasm
       run: sudo apt-get update --fix-missing && sudo apt-get install qemu-system-x86 nasm
+    - name: Set override for Rust version
+      run: |
+        rustup override set ${{ matrix.rust }}
+        cd loader && rustup override set ${{ matrix.rust }}
     - name: Building dev version
       run:
          cargo build -Z build-std=std,core,alloc,panic_abort --target x86_64-unknown-hermit


### PR DESCRIPTION
Building release version with lto optimization fails with nightlies after 2020-04-29, so we just use that one for now.