### PR TITLE
disable LTO support to avoid compiler conflicts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = ["target", "loader", "libhermit-rs"]
 opt-level = 3
 debug = false
 rpath = false
-lto = true
+lto = false
 debug-assertions = false
 
 [profile.dev]


### PR DESCRIPTION
This path should solve issue #7. Using an old version of the rust compiler #11 is also a solution, but we still integrate our libos into rust-lang/rust#71591. Consequently, we are interested in latest version of the nightly compiler.