### PR TITLE
Build: Rebuild when libhermit-rs is modified

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,7 @@ dependencies = [
  "log",
  "rftrace",
  "smoltcp",
+ "walkdir",
  "x86",
 ]
 
@@ -418,6 +419,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +547,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
+name = "walkdir"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+dependencies = [
+ "same-file",
+ "winapi 0.3.8",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,6 +590,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi 0.3.8",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/hermit-sys/Cargo.toml
+++ b/hermit-sys/Cargo.toml
@@ -16,6 +16,9 @@ build = "build.rs"
 instrument = ["rftrace"]
 trace = []
 
+[build-dependencies]
+walkdir = "2"
+
 [dependencies]
 log = { version = "0.4", default-features = false }
 lazy_static = "1.4.0"


### PR DESCRIPTION
Uses the` cargo:rerun-if-changed=PATH `directive to inform cargo which files in libhermit-rs should be watched and trigger a rebuild of hermit-sys. We don't need to do this for the files in hermit-sys, since cargo already watches those.
I used [this pattern](https://rust-lang-nursery.github.io/rust-cookbook/file/dir.html#traverse-directories-while-skipping-dotfiles) as a template.