### PR TITLE
remove dependency to xbuild

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,8 +40,8 @@ jobs:
       run: cargo --version
     - name: Install cargo-download
       run: cargo install cargo-download
-    - name: Install qemu/nasm
-      run: sudo apt-get update --fix-missing && sudo apt-get install qemu-system-x86 nasm
+    - name: Install qemu/nasm/llvm
+      run: sudo apt-get update --fix-missing && sudo apt-get install qemu-system-x86 nasm llvm
     - name: Building dev version
       run:
          cargo build -Z build-std=std,core,alloc,panic_abort --target x86_64-unknown-hermit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,8 +40,6 @@ jobs:
       run: cargo --version
     - name: Install cargo-download
       run: cargo install cargo-download
-    - name: Install xbuild
-      run: cargo install cargo-xbuild
     - name: Install qemu/nasm
       run: sudo apt-get update --fix-missing && sudo apt-get install qemu-system-x86 nasm
     - name: Building dev version

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,7 +61,6 @@ build:
 test:qemu:
    stage: test
    script:
-     - cargo install cargo-xbuild
      - cd loader
      - make
      - qemu-system-x86_64 -display none -smp 1 -m 64M -serial stdio -kernel target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd ../target/x86_64-unknown-hermit/debug/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr,rdrand


### PR DESCRIPTION
The kernel doesn't longer depend on xbuild. We should also remove the dependency from the loader.