### PR TITLE
Log: Add option to set LevelFilter at compile time

### DIFF
--- a/hermit-sys/src/lib.rs
+++ b/hermit-sys/src/lib.rs
@@ -36,10 +36,18 @@ impl log::Log for SysLogger {
 #[no_mangle]
 pub extern "C" fn sys_network_init() -> i32 {
 	set_logger(&SysLogger).expect("Can't initialize logger");
-	#[cfg(feature = "trace")]
-	set_max_level(LevelFilter::Trace);
-	#[cfg(not(feature = "trace"))]
-	set_max_level(LevelFilter::Info);
+	// Determines LevelFilter at compile time
+	let log_level: Option<&'static str> = option_env!("HERMIT_LOG_LEVEL_FILTER");
+	let max_level: LevelFilter = match log_level {
+		Some("Error") => LevelFilter::Error,
+		Some("Debug") => LevelFilter::Debug,
+		Some("Off") => LevelFilter::Off,
+		Some("Trace") => LevelFilter::Trace,
+		Some("Warn") => LevelFilter::Warn,
+		Some("Info") => LevelFilter::Info,
+		_ => LevelFilter::Info,
+	};
+	set_max_level(max_level);
 
 	#[cfg(feature = "smoltcp")]
 	let ret: i32 = if net::network_init().is_ok() { 0 } else { -1 };


### PR DESCRIPTION
In principle, this patch is an extension of hermitcore/libhermit-rs#53.
If the Environment variable HERMIT_LOG_LEVEL_FILTER is set at compile time to a string matching the Name of a Levelfilter enum value, then that value is used for the Levelfilter.
If the Environment variable is not set, or the name doesn't match, then LevelFilter::Info is used by default, which is the same as it was before.