### PR TITLE
CI: Add windows and macOS to matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,6 @@ name: Test
 
 on:
   push:
-    branches:
-      - master
-      - devel
   pull_request:
     branches:
       - master
@@ -19,13 +16,21 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [nightly]
         include:
           - os: ubuntu-latest
             rust: 'nightly'
             components: 'rust-src, llvm-tools-preview'
             targets: 'x86_64-unknown-linux-gnu'
+          - os: macOS-latest
+            rust: 'nightly'
+            components: 'rust-src, llvm-tools-preview'
+            targets: 'x86_64-apple-darwin'
+          - os: windows-latest
+            rust: 'nightly'
+            components: 'rust-src, llvm-tools-preview'
+            targets: 'x86_64-pc-windows-msvc'
 
     steps:
     - uses: hecrj/setup-rust-action@v1.3.1
@@ -38,10 +43,23 @@ jobs:
          submodules: true
     - name: Check Cargo availability
       run: cargo --version
-    - name: Install cargo-download
-      run: cargo install cargo-download
-    - name: Install qemu/nasm
+    - name: Install qemu/nasm (ubuntu)
       run: sudo apt-get update --fix-missing && sudo apt-get install qemu-system-x86 nasm
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+    - name: Install qemu/nasm/binutils (macos)
+      run: |
+          brew update && brew install qemu nasm binutils
+          echo "::add-path::/usr/local/Cellar/binutils/2.34/bin/"
+      if: ${{ matrix.os == 'macOS-latest' }}
+    - name: Install qemu/nasm (windows)
+      run: |
+          choco install qemu nasm
+          echo "::add-path::C:\Program Files\NASM"
+          echo "::add-path::C:\Program Files\qemu"
+      if: ${{ matrix.os == 'windows-latest' }}
+    - name: Building dev version
+      run:
+          cargo build -Z build-std=std,core,alloc,panic_abort --target x86_64-unknown-hermit
     - name: Building dev version
       run:
          cargo build -Z build-std=std,core,alloc,panic_abort --target x86_64-unknown-hermit
@@ -49,17 +67,30 @@ jobs:
       run:
          cargo build -Z build-std=std,core,alloc,panic_abort --target x86_64-unknown-hermit --release
     - name: Build loader
-      run:
-         cd loader && make
+      working-directory: loader
+      run: make
+    # Workaround since makefile doesn't work when using powershell
+    - name: Build loader (windows)
+      working-directory: loader
+      run: |
+          cargo build -Z build-std=core,alloc --target x86_64-unknown-hermit-loader.json
+          $VAR_RUSTC_SYSROOT = (rustc --print sysroot)
+          echo "Sysroot - $VAR_RUSTC_SYSROOT"
+          $LLVM_OBJCOPY = ((Get-ChildItem -Path $VAR_RUSTC_SYSROOT -Include llvm-objcopy.exe -File -Recurse -ErrorAction SilentlyContinue)).Fullname
+          echo "LLVM Objcopy - $LLVM_OBJCOPY"
+          Invoke-Expression "$LLVM_OBJCOPY --strip-debug -O elf32-i386 target/x86_64-unknown-hermit-loader/debug/rusty-loader"
+      if: ${{ matrix.os == 'windows-latest' }}
     - name: Test dev version
       run:
          qemu-system-x86_64 -display none -smp 1 -m 64M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/debug/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr,rdrand
     - name: Test dev version (smp)
       run:
          qemu-system-x86_64 -display none -smp 2 -m 64M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/debug/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr,rdrand
+      timeout-minutes: 20   
     - name: Test release version
       run:
          qemu-system-x86_64 -display none -smp 1 -m 64M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/release/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr,rdrand
     - name: Test release version (smp)
       run:
          qemu-system-x86_64 -display none -smp 2 -m 64M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/release/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr,rdrand
+      timeout-minutes: 20


### PR DESCRIPTION
Run rusty-demo on qemu on all three systems.
This PR basically ports the improvements from https://github.com/hermitcore/libhermit-rs/pull/40 to this repo. 