### PR TITLE
Use rust 2018 edtion

### DIFF
--- a/hermit-abi/Cargo.toml
+++ b/hermit-abi/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.13"
 authors = ["Stefan Lankes"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
+edition = "2018"
 description = """
 hermit-abi is small interface to call functions from the unikernel RustyHermit.
 It is used to build the target `x86_64-unknown-hermit`.

--- a/hermit-sys/Cargo.toml
+++ b/hermit-sys/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["unikernel", "libos"]
 categories = ["os"]
 links = "hermit"
 build = "build.rs"
+edition = "2018"
 
 [features]
 # controlls whether RustyHermit is build with -Z instrument-mcount

--- a/hermit-sys/src/net/device.rs
+++ b/hermit-sys/src/net/device.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeMap;
 use std::convert::TryInto;
 use std::slice;
 
-use net::NetworkInterface;
 use smoltcp::iface::{EthernetInterfaceBuilder, NeighborCache, Routes};
 #[cfg(feature = "trace")]
 use smoltcp::phy::EthernetTracer;
@@ -10,6 +9,8 @@ use smoltcp::phy::{self, Device, DeviceCapabilities};
 use smoltcp::socket::SocketSet;
 use smoltcp::time::Instant;
 use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr, Ipv4Address};
+
+use crate::net::NetworkInterface;
 
 extern "Rust" {
 	fn sys_get_mac_address() -> Result<[u8; 6], ()>;

--- a/hermit-sys/src/net/mod.rs
+++ b/hermit-sys/src/net/mod.rs
@@ -1,6 +1,3 @@
-pub mod device;
-
-use crossbeam_channel::{Receiver, Sender};
 use std::arch::x86_64::_rdtsc;
 use std::collections::BTreeMap;
 use std::str::FromStr;
@@ -8,6 +5,7 @@ use std::sync::atomic::{AtomicU16, Ordering};
 use std::sync::Mutex;
 use std::u16;
 
+use crossbeam_channel::{Receiver, Sender};
 use smoltcp::phy::Device;
 #[cfg(feature = "trace")]
 use smoltcp::phy::EthernetTracer;
@@ -15,7 +13,9 @@ use smoltcp::socket::{SocketHandle, SocketSet, TcpSocket, TcpSocketBuffer, TcpSt
 use smoltcp::time::Instant;
 use smoltcp::wire::IpAddress;
 
-use net::device::HermitNet;
+use crate::net::device::HermitNet;
+
+pub mod device;
 
 lazy_static! {
 	static ref NIC: Mutex<Option<NetworkInterface<HermitNet>>> =


### PR DESCRIPTION
Bumps the edition to 2018 for hermit-sys and hermit-abi. 