### PR TITLE
Cleanup

### DIFF
--- a/demo/src/tests/matmul.rs
+++ b/demo/src/tests/matmul.rs
@@ -1,9 +1,8 @@
+use std::time::Instant;
+
 /// Code is derived Rayon's matmul example
 /// https://github.com/rayon-rs/rayon/tree/master/rayon-demo/src/matmul
-use rayon;
 use rayon::prelude::*;
-
-use std::time::Instant;
 
 // TODO: Investigate other cache patterns for row-major order that may be more
 // parallelizable.
@@ -100,7 +99,7 @@ fn seq_matmulz(a: &[f32], b: &[f32], dest: &mut [f32]) {
 	}
 }
 
-const MULT_CHUNK: usize = 1 * 1024;
+const MULT_CHUNK: usize = 1024;
 const LINEAR_CHUNK: usize = 64 * 1024;
 
 fn quarter_chunks(v: &[f32]) -> (&[f32], &[f32], &[f32], &[f32]) {

--- a/hermit-abi/src/tcpstream.rs
+++ b/hermit-abi/src/tcpstream.rs
@@ -75,7 +75,7 @@ pub fn get_write_timeout(handle: Handle) -> Result<Option<u64>, ()> {
 pub fn set_nodelay(_: Handle, mode: bool) -> Result<(), ()> {
 	// smoltcp does not support Nagle's algorithm
 	// => to enable Nagle's algorithm isn't possible
-	if mode == true {
+	if mode {
 		Ok(())
 	} else {
 		Err(())

--- a/hermit-abi/src/tcpstream.rs
+++ b/hermit-abi/src/tcpstream.rs
@@ -74,7 +74,7 @@ pub fn get_write_timeout(handle: Handle) -> Result<Option<u64>, ()> {
 #[inline(always)]
 pub fn set_nodelay(_: Handle, mode: bool) -> Result<(), ()> {
 	// smoltcp does not support Nagle's algorithm
-	// => to enable Nagle's algorithm ins't possineö
+	// => to enable Nagle's algorithm isn't possible
 	if mode == true {
 		Ok(())
 	} else {

--- a/hermit-sys/build.rs
+++ b/hermit-sys/build.rs
@@ -2,6 +2,7 @@ extern crate walkdir;
 
 use std::env;
 use std::process::Command;
+
 use walkdir::{DirEntry, WalkDir};
 
 #[cfg(all(not(feature = "rustc-dep-of-std"), not(feature = "with_submodule")))]
@@ -41,7 +42,7 @@ fn build() {
 	cmd.env(
 		"RUSTFLAGS",
 		env::var("RUSTFLAGS")
-			.unwrap_or("".into())
+			.unwrap_or_else(|_| "".into())
 			.replace("-Z instrument-mcount", ""),
 	);
 
@@ -88,7 +89,7 @@ fn build() {
 	cmd.env(
 		"RUSTFLAGS",
 		env::var("RUSTFLAGS")
-			.unwrap_or("".into())
+			.unwrap_or_else(|_| "".into())
 			.replace("-Z instrument-mcount", ""),
 	);
 
@@ -102,8 +103,7 @@ fn build() {
 
 	println!(
 		"cargo:rustc-link-search=native={}/target/x86_64-unknown-hermit-kernel/{}",
-		out_dir.clone(),
-		profile
+		out_dir, profile
 	);
 	println!("cargo:rustc-link-lib=static=hermit");
 }
@@ -112,13 +112,13 @@ fn build() {
 fn configure_cargo_rerun_if_changed() {
 	fn is_not_ignored(entry: &DirEntry) -> bool {
 		// Ignore .git .vscode and target directories, but not .cargo or .github
-		if entry.depth() == 1 && entry.path().is_dir() {
-			if entry.path().ends_with("target")
+		if entry.depth() == 1
+			&& entry.path().is_dir()
+			&& (entry.path().ends_with("target")
 				|| entry.path().ends_with(".git")
-				|| entry.path().ends_with(".vscode")
-			{
-				return false;
-			}
+				|| entry.path().ends_with(".vscode"))
+		{
+			return false;
 		}
 		true
 	}

--- a/hermit-sys/src/net/device.rs
+++ b/hermit-sys/src/net/device.rs
@@ -85,7 +85,7 @@ impl NetworkInterface<HermitNet> {
 
 		info!("MAC address {}", ethernet_addr);
 		info!("Configure network interface with address {}", ip_addrs[0]);
-		info!("Configure gatway with address {}", default_v4_gw);
+		info!("Configure gateway with address {}", default_v4_gw);
 		info!("MTU: {} bytes", mtu);
 
 		let iface = EthernetInterfaceBuilder::new(device)

--- a/hermit-sys/src/net/mod.rs
+++ b/hermit-sys/src/net/mod.rs
@@ -262,8 +262,7 @@ pub fn sys_tcp_stream_connect(ip: &[u8], port: u16, timeout: Option<u64>) -> Res
 		let mut guard = NIC.lock().map_err(|_| ())?;
 		let nic = guard.as_mut().ok_or(())?;
 		let handle = nic.connect(ip, port)?;
-		nic.channels
-			.insert(handle, (WaitFor::Establish, tx.clone(), false));
+		nic.channels.insert(handle, (WaitFor::Establish, tx, false));
 
 		handle
 	};
@@ -406,7 +405,7 @@ pub fn sys_tcp_stream_close(handle: Handle) -> Result<(), ()> {
 		nic.close(handle)?;
 		*nic.channels
 			.get_mut(&handle)
-			.expect("Unable to find handle") = (WaitFor::Close, tx.clone(), false);
+			.expect("Unable to find handle") = (WaitFor::Close, tx, false);
 
 		// transfer request to nic
 		while let Some(delay) = nic.poll() {


### PR DESCRIPTION
Fix, typos optimize imports address linter warnings .

Please ensure that the removed `clone()` in `hermit-sys/src/net/mod.rs` is correct. The linter flagged it as an unnecessary clone and from my understanding tx would have been dropped anyway, so the clone is indeed unnecessary. But please double check this anyway.