### PR TITLE
build.rs: Rebuild if HERMIT_LOG_LEVEL_FILTER changed

### DIFF
--- a/hermit-sys/build.rs
+++ b/hermit-sys/build.rs
@@ -129,6 +129,9 @@ fn configure_cargo_rerun_if_changed() {
 		.filter_map(|v| v.ok())
 		.filter_map(|v| v.path().canonicalize().ok())
 		.for_each(|x| println!("cargo:rerun-if-changed={}", x.display()));
+
+	//HERMIT_LOG_LEVEL_FILTER sets the log level filter at compile time
+	println!("cargo:rerun-if-env-changed=HERMIT_LOG_LEVEL_FILTER");
 }
 
 fn main() {


### PR DESCRIPTION
HERMIT_LOG_LEVEL_FILTER sets the filter at compile time so a rebuild is required if the environment variable changes.
This PR currently only rebuilds for the feature `with_submodule`, should this also be done for the build with cargo-download?