### PR TITLE
Build: Refactor to reduce duplicated Code

### DIFF
--- a/hermit-sys/build.rs
+++ b/hermit-sys/build.rs
@@ -1,36 +1,29 @@
 extern crate walkdir;
 
 use std::env;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use walkdir::{DirEntry, WalkDir};
 
-#[cfg(all(not(feature = "rustc-dep-of-std"), not(feature = "with_submodule")))]
-fn build() {
-	#[cfg(windows)]
-	let out_dir = env::temp_dir().to_str().unwrap().to_owned();
-	#[cfg(not(windows))]
-	let out_dir = env::var("OUT_DIR").unwrap();
+fn build_hermit(src_dir: &Path, target_dir_opt: Option<&Path>) {
 	let profile = env::var("PROFILE").expect("PROFILE was not set");
-
-	let _output = Command::new("cargo")
-		.current_dir(out_dir.clone())
-		.arg("download")
-		.arg("--output")
-		.arg(out_dir.clone() + "/rusty-hermit")
-		.arg("--extract")
-		.arg("rusty-hermit")
-		.output()
-		.expect("Unable to download rusty-hermit. Please install `cargo-download`.");
-
 	let mut cmd = Command::new("cargo");
-	cmd.current_dir(out_dir.clone() + "/rusty-hermit")
+	cmd.current_dir(src_dir)
 		.arg("build")
 		.arg("-Z")
 		.arg("build-std=core,alloc")
 		.arg("--target")
 		.arg("x86_64-unknown-hermit-kernel");
 
+	if let Some(target_dir) = target_dir_opt {
+		cmd.arg("--target-dir").arg(target_dir);
+	}
+	let target_dir = match target_dir_opt {
+		Some(target_dir) => target_dir.to_path_buf(),
+		None => src_dir.join("target"),
+	};
+
 	if profile == "release" {
 		cmd.arg("--release");
 	}
@@ -49,67 +42,62 @@ fn build() {
 	let output = cmd.output().expect("Unable to build kernel");
 	let stdout = std::string::String::from_utf8(output.stdout);
 	let stderr = std::string::String::from_utf8(output.stderr);
+
 	println!("Build libhermit-rs output-status: {}", output.status);
 	println!("Build libhermit-rs output-stdout: {}", stdout.unwrap());
 	println!("Build libhermit-rs output-stderr: {}", stderr.unwrap());
 	assert!(output.status.success());
 
-	println!(
-		"cargo:rustc-link-search=native={}/rusty-hermit/target/x86_64-unknown-hermit-kernel/{}",
-		out_dir.clone(),
-		profile
-	);
+	let lib_location = target_dir
+		.join("x86_64-unknown-hermit-kernel")
+		.join(&profile)
+		.canonicalize()
+		.unwrap(); // Must exist after building
+	println!("cargo:rustc-link-search=native={}", lib_location.display());
 	println!("cargo:rustc-link-lib=static=hermit");
+
+	//HERMIT_LOG_LEVEL_FILTER sets the log level filter at compile time
+	// Doesn't actually rebuild atm - see: https://github.com/rust-lang/cargo/issues/8306
+	println!("cargo:rerun-if-env-changed=HERMIT_LOG_LEVEL_FILTER");
+}
+
+#[cfg(all(not(feature = "rustc-dep-of-std"), not(feature = "with_submodule")))]
+fn build() {
+	#[cfg(windows)]
+	let out_dir = env::temp_dir();
+	#[cfg(not(windows))]
+	let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+	let src_dir = out_dir.join("rusty-hermit");
+
+	let _output = Command::new("cargo")
+		.current_dir(out_dir)
+		.arg("download")
+		.arg("--output")
+		.arg(src_dir.clone().into_os_string())
+		.arg("--extract")
+		.arg("rusty-hermit")
+		.output()
+		.expect("Unable to download rusty-hermit. Please install `cargo-download`.");
+
+	build_hermit(src_dir.as_ref(), None);
 }
 
 #[cfg(all(not(feature = "rustc-dep-of-std"), feature = "with_submodule"))]
 fn build() {
-	let out_dir = env::var("OUT_DIR").unwrap();
-	let target_dir = out_dir.clone() + "/target";
-	let profile = env::var("PROFILE").expect("PROFILE was not set");
+	let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+	let target_dir = out_dir.clone().join("target");
+	let src_dir = env::current_dir()
+		.unwrap()
+		.parent()
+		.unwrap()
+		.join("libhermit-rs");
 
-	let mut cmd = Command::new("cargo");
-	cmd.current_dir("../libhermit-rs")
-		.arg("build")
-		.arg("-Z")
-		.arg("build-std=core,alloc")
-		.arg("--target")
-		.arg("x86_64-unknown-hermit-kernel")
-		.arg("--target-dir")
-		.arg(target_dir);
-
-	if profile == "release" {
-		cmd.arg("--release");
-	}
-
-	#[cfg(feature = "instrument")]
-	cmd.env("RUSTFLAGS", "-Z instrument-mcount");
-	// if instrument is not set, ensure that instrument is not in environment variables!
-	#[cfg(not(feature = "instrument"))]
-	cmd.env(
-		"RUSTFLAGS",
-		env::var("RUSTFLAGS")
-			.unwrap_or_else(|_| "".into())
-			.replace("-Z instrument-mcount", ""),
-	);
-
-	let output = cmd.output().expect("Unable to build kernel");
-	let stdout = std::string::String::from_utf8(output.stdout);
-	let stderr = std::string::String::from_utf8(output.stderr);
-	println!("Build libhermit-rs output-status: {}", output.status);
-	println!("Build libhermit-rs output-stdout: {}", stdout.unwrap());
-	println!("Build libhermit-rs output-stderr: {}", stderr.unwrap());
-	assert!(output.status.success());
-
-	println!(
-		"cargo:rustc-link-search=native={}/target/x86_64-unknown-hermit-kernel/{}",
-		out_dir, profile
-	);
-	println!("cargo:rustc-link-lib=static=hermit");
+	build_hermit(src_dir.as_ref(), Some(target_dir.as_ref()));
+	configure_cargo_rerun_if_changed(src_dir.as_ref());
 }
 
 #[cfg(all(not(feature = "rustc-dep-of-std"), feature = "with_submodule"))]
-fn configure_cargo_rerun_if_changed() {
+fn configure_cargo_rerun_if_changed(src_dir: &Path) {
 	fn is_not_ignored(entry: &DirEntry) -> bool {
 		// Ignore .git .vscode and target directories, but not .cargo or .github
 		if entry.depth() == 1
@@ -123,7 +111,7 @@ fn configure_cargo_rerun_if_changed() {
 		true
 	}
 
-	WalkDir::new("../libhermit-rs")
+	WalkDir::new(src_dir)
 		.into_iter()
 		.filter_entry(|e| is_not_ignored(e))
 		.filter_map(|v| v.ok())
@@ -132,8 +120,6 @@ fn configure_cargo_rerun_if_changed() {
 }
 
 fn main() {
-	#[cfg(all(not(feature = "rustc-dep-of-std"), feature = "with_submodule"))]
-	configure_cargo_rerun_if_changed();
 	#[cfg(not(feature = "rustc-dep-of-std"))]
 	build();
 }


### PR DESCRIPTION
- Move duplicate code into build_hermit method
- Use Path and PathBuf instead of Strings
- Trigger a rebuild of hermit when HERMIT_LOG_LEVEL_FILTER changes. This doesn't have the desired effect yet, since cargo won't rebuild the file containing the option_env since it doesn't keep track of option_envs yet. There might be support for it soon though.