### PR TITLE
add libm support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,7 @@ version = "0.1.13"
 dependencies = [
  "crossbeam-channel",
  "lazy_static",
+ "libm",
  "log",
  "smoltcp",
  "walkdir",
@@ -232,6 +233,12 @@ checksum = "3baa92041a6fec78c687fa0cc2b3fae8884f743d672cf551bed1d6dac6988d0f"
 dependencies = [
  "rustc-std-workspace-core",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "log"

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -31,6 +31,11 @@ fn main() {
 	println!("Test {} ... {}", stringify!(hello), test_result(hello()));
 	println!(
 		"Test {} ... {}",
+		stringify!(arithmetic),
+		test_result(arithmetic())
+	);
+	println!(
+		"Test {} ... {}",
 		stringify!(print_argv),
 		test_result(print_argv())
 	);

--- a/demo/src/tests/mod.rs
+++ b/demo/src/tests/mod.rs
@@ -1,7 +1,7 @@
 use core::arch::x86_64 as arch;
 use rand::prelude::*;
 use std::env;
-use std::f64::consts::PI;
+use std::f64::consts::{E, PI};
 use std::fs::File;
 use std::io::Read;
 use std::io::Write;
@@ -275,6 +275,18 @@ pub fn hello() -> Result<(), ()> {
 		"Crab emoji: {}",
 		String::from_utf8(crab).unwrap_or_default()
 	);
+
+	Ok(())
+}
+
+pub fn arithmetic() -> Result<(), ()> {
+	let mut rng = rand::thread_rng();
+	let x = rng.gen::<f64>();
+	let y: f64 = x.exp();
+	let z: f64 = y.log(E);
+
+	println!("x = {}, e^x = {}, ln(e^x) = {}", x, y, z);
+
 	Ok(())
 }
 

--- a/hermit-sys/Cargo.toml
+++ b/hermit-sys/Cargo.toml
@@ -25,6 +25,7 @@ walkdir = "2"
 [dependencies]
 log = { version = "0.4", default-features = false }
 lazy_static = "1.4.0"
+libm = { version = "0.2.1", default-features = false }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies.x86]
 version = "0.*"

--- a/hermit-sys/src/cmath.rs
+++ b/hermit-sys/src/cmath.rs
@@ -50,6 +50,7 @@ pub extern "C" fn atan2(a: f64, b: f64) -> f64 {
 	libm::atan2(a, b)
 }
 
+#[no_mangle]
 pub extern "C" fn atan2f(a: f32, b: f32) -> f32 {
 	libm::atan2f(a, b)
 }
@@ -144,7 +145,8 @@ pub extern "C" fn log(x: f64) -> f64 {
 	libm::log(x)
 }
 
-pub fn logf(x: f32) -> f32 {
+#[no_mangle]
+pub extern "C" fn logf(x: f32) -> f32 {
 	libm::logf(x)
 }
 

--- a/hermit-sys/src/cmath.rs
+++ b/hermit-sys/src/cmath.rs
@@ -12,12 +12,12 @@ pub extern "C" fn acosf(n: f32) -> f32 {
 
 #[no_mangle]
 pub extern "C" fn acosh(x: f64) -> f64 {
-    libm::acosh(x)
+	libm::acosh(x)
 }
 
 #[no_mangle]
 pub extern "C" fn acoshf(x: f32) -> f32 {
-    libm::acoshf(x)
+	libm::acoshf(x)
 }
 
 #[no_mangle]
@@ -32,12 +32,12 @@ pub extern "C" fn asinf(n: f32) -> f32 {
 
 #[no_mangle]
 pub extern "C" fn asinh(x: f64) -> f64 {
-    libm::asinh(x)
+	libm::asinh(x)
 }
 
 #[no_mangle]
 pub extern "C" fn asinhf(x: f32) -> f32 {
-    libm::asinhf(x)
+	libm::asinhf(x)
 }
 
 #[no_mangle]
@@ -71,32 +71,32 @@ pub extern "C" fn cbrtf(n: f32) -> f32 {
 
 #[no_mangle]
 pub extern "C" fn ceil(x: f64) -> f64 {
-    libm::ceil(x)
+	libm::ceil(x)
 }
 
 #[no_mangle]
 pub extern "C" fn ceilf(x: f32) -> f32 {
-    libm::ceilf(x)
+	libm::ceilf(x)
 }
 
 #[no_mangle]
 pub extern "C" fn cos(x: f64) -> f64 {
-    libm::cos(x)
+	libm::cos(x)
 }
 
 #[no_mangle]
 pub extern "C" fn cosf(x: f32) -> f32 {
-    libm::cosf(x)
+	libm::cosf(x)
 }
 
 #[no_mangle]
 pub extern "C" fn cosh(x: f64) -> f64 {
-    libm::cosh(x)
+	libm::cosh(x)
 }
 
 #[no_mangle]
 pub extern "C" fn coshf(x: f32) -> f32 {
-    libm::coshf(x)
+	libm::coshf(x)
 }
 
 #[no_mangle]
@@ -170,12 +170,12 @@ pub extern "C" fn sinhf(n: f32) -> f32 {
 
 #[no_mangle]
 pub extern "C" fn sqrt(x: f64) -> f64 {
-    libm::sqrt(x)
+	libm::sqrt(x)
 }
 
 #[no_mangle]
 pub extern "C" fn sqrtf(x: f32) -> f32 {
-    libm::sqrtf(x)
+	libm::sqrtf(x)
 }
 
 #[no_mangle]

--- a/hermit-sys/src/cmath.rs
+++ b/hermit-sys/src/cmath.rs
@@ -11,6 +11,16 @@ pub extern "C" fn acosf(n: f32) -> f32 {
 }
 
 #[no_mangle]
+pub extern "C" fn acosh(x: f64) -> f64 {
+    libm::acosh(x)
+}
+
+#[no_mangle]
+pub extern "C" fn acoshf(x: f32) -> f32 {
+    libm::acoshf(x)
+}
+
+#[no_mangle]
 pub extern "C" fn asin(n: f64) -> f64 {
 	libm::asin(n)
 }
@@ -18,6 +28,16 @@ pub extern "C" fn asin(n: f64) -> f64 {
 #[no_mangle]
 pub extern "C" fn asinf(n: f32) -> f32 {
 	libm::asinf(n)
+}
+
+#[no_mangle]
+pub extern "C" fn asinh(x: f64) -> f64 {
+    libm::asinh(x)
+}
+
+#[no_mangle]
+pub extern "C" fn asinhf(x: f32) -> f32 {
+    libm::asinhf(x)
 }
 
 #[no_mangle]
@@ -50,13 +70,33 @@ pub extern "C" fn cbrtf(n: f32) -> f32 {
 }
 
 #[no_mangle]
-pub extern "C" fn cosh(n: f64) -> f64 {
-	libm::cosh(n)
+pub extern "C" fn ceil(x: f64) -> f64 {
+    libm::ceil(x)
 }
 
 #[no_mangle]
-pub extern "C" fn coshf(n: f32) -> f32 {
-	libm::coshf(n)
+pub extern "C" fn ceilf(x: f32) -> f32 {
+    libm::ceilf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn cos(x: f64) -> f64 {
+    libm::cos(x)
+}
+
+#[no_mangle]
+pub extern "C" fn cosf(x: f32) -> f32 {
+    libm::cosf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn cosh(x: f64) -> f64 {
+    libm::cosh(x)
+}
+
+#[no_mangle]
+pub extern "C" fn coshf(x: f32) -> f32 {
+    libm::coshf(x)
 }
 
 #[no_mangle]
@@ -126,6 +166,16 @@ pub extern "C" fn sinh(n: f64) -> f64 {
 #[no_mangle]
 pub extern "C" fn sinhf(n: f32) -> f32 {
 	libm::sinhf(n)
+}
+
+#[no_mangle]
+pub extern "C" fn sqrt(x: f64) -> f64 {
+    libm::sqrt(x)
+}
+
+#[no_mangle]
+pub extern "C" fn sqrtf(x: f32) -> f32 {
+    libm::sqrtf(x)
 }
 
 #[no_mangle]

--- a/hermit-sys/src/cmath.rs
+++ b/hermit-sys/src/cmath.rs
@@ -1,0 +1,149 @@
+#![allow(dead_code)]
+
+#[no_mangle]
+pub extern "C" fn acos(n: f64) -> f64 {
+	libm::acos(n)
+}
+
+#[no_mangle]
+pub extern "C" fn acosf(n: f32) -> f32 {
+	libm::acosf(n)
+}
+
+#[no_mangle]
+pub extern "C" fn asin(n: f64) -> f64 {
+	libm::asin(n)
+}
+
+#[no_mangle]
+pub extern "C" fn asinf(n: f32) -> f32 {
+	libm::asinf(n)
+}
+
+#[no_mangle]
+pub extern "C" fn atan(n: f64) -> f64 {
+	libm::atan(n)
+}
+
+#[no_mangle]
+pub extern "C" fn atan2(a: f64, b: f64) -> f64 {
+	libm::atan2(a, b)
+}
+
+pub extern "C" fn atan2f(a: f32, b: f32) -> f32 {
+	libm::atan2f(a, b)
+}
+
+#[no_mangle]
+pub extern "C" fn atanf(n: f32) -> f32 {
+	libm::atanf(n)
+}
+
+#[no_mangle]
+pub extern "C" fn cbrt(n: f64) -> f64 {
+	libm::cbrt(n)
+}
+
+#[no_mangle]
+pub extern "C" fn cbrtf(n: f32) -> f32 {
+	libm::cbrtf(n)
+}
+
+#[no_mangle]
+pub extern "C" fn cosh(n: f64) -> f64 {
+	libm::cosh(n)
+}
+
+#[no_mangle]
+pub extern "C" fn coshf(n: f32) -> f32 {
+	libm::coshf(n)
+}
+
+#[no_mangle]
+pub extern "C" fn exp(x: f64) -> f64 {
+	libm::exp(x)
+}
+
+#[no_mangle]
+pub extern "C" fn expf(x: f32) -> f32 {
+	libm::expf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn expm1(n: f64) -> f64 {
+	libm::expm1(n)
+}
+
+#[no_mangle]
+pub extern "C" fn expm1f(n: f32) -> f32 {
+	libm::expm1f(n)
+}
+
+#[no_mangle]
+pub extern "C" fn fdim(a: f64, b: f64) -> f64 {
+	libm::fdim(a, b)
+}
+
+#[no_mangle]
+pub extern "C" fn fdimf(a: f32, b: f32) -> f32 {
+	libm::fdimf(a, b)
+}
+
+#[no_mangle]
+pub extern "C" fn hypot(x: f64, y: f64) -> f64 {
+	libm::hypot(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn hypotf(x: f32, y: f32) -> f32 {
+	libm::hypotf(x, y)
+}
+
+#[no_mangle]
+pub extern "C" fn log(x: f64) -> f64 {
+	libm::log(x)
+}
+
+pub fn logf(x: f32) -> f32 {
+	libm::logf(x)
+}
+
+#[no_mangle]
+pub extern "C" fn log1p(n: f64) -> f64 {
+	libm::log1p(n)
+}
+
+#[no_mangle]
+pub extern "C" fn log1pf(n: f32) -> f32 {
+	libm::log1pf(n)
+}
+
+#[no_mangle]
+pub extern "C" fn sinh(n: f64) -> f64 {
+	libm::sinh(n)
+}
+
+#[no_mangle]
+pub extern "C" fn sinhf(n: f32) -> f32 {
+	libm::sinhf(n)
+}
+
+#[no_mangle]
+pub extern "C" fn tan(n: f64) -> f64 {
+	libm::tan(n)
+}
+
+#[no_mangle]
+pub extern "C" fn tanf(n: f32) -> f32 {
+	libm::tanf(n)
+}
+
+#[no_mangle]
+pub extern "C" fn tanh(n: f64) -> f64 {
+	libm::tanh(n)
+}
+
+#[no_mangle]
+pub extern "C" fn tanhf(n: f32) -> f32 {
+	libm::tanhf(n)
+}

--- a/hermit-sys/src/lib.rs
+++ b/hermit-sys/src/lib.rs
@@ -6,7 +6,9 @@ extern crate smoltcp;
 extern crate x86;
 #[macro_use]
 extern crate lazy_static;
+extern crate libm;
 
+mod cmath;
 #[cfg(not(feature = "smoltcp"))]
 mod dummy;
 #[cfg(feature = "smoltcp")]


### PR DESCRIPTION
libm is port of MUSL's libm to Rust. This crate is used to support basic arithmetic functions.