### PR TITLE
Removed old demo.gif

### DIFF
--- a/img/demo.gif
+++ b/img/demo.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:36029b7d5a678a63b01fcbdc73a2bc732585c7bfe9e040a5337c395b7b65da24
-size 12062419


### PR DESCRIPTION
The demo is not used and  quite huge. Unfortunately it is already in the history now.