### PR TITLE
add support of TcpListener of libstd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ascii"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbf56136a5198c7b01a49e3afcbef6cf84597273d298f54432926024107b0109"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,6 +67,22 @@ name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "chrono"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "chunked_transfer"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b89647f09b9f4c838cb622799b2843e4e13bff64661dab9a0362bb92985addd"
 
 [[package]]
 name = "clap"
@@ -209,6 +231,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "httpd"
+version = "0.1.0"
+dependencies = [
+ "hermit-sys",
+ "tiny_http",
+]
+
+[[package]]
+name = "idna"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +290,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdcec5e97041c7f0f1c5b7d93f12e57293c831c646f4cc7a5db59460c7ea8de6"
 
 [[package]]
+name = "matches"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+
+[[package]]
 name = "maybe-uninit"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +311,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +338,12 @@ dependencies = [
  "hermit-abi 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "ppv-lite86"
@@ -471,6 +543,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
+
+[[package]]
 name = "smoltcp"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,6 +598,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny_http"
+version = "0.7.0"
+source = "git+https://github.com/hermitcore/tiny-http.git#e5865e0d4824b0df80a335a4dd671b98be45f4e9"
+dependencies = [
+ "ascii",
+ "chrono",
+ "chunked_transfer",
+ "log",
+ "url",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+dependencies = [
+ "matches",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,6 +638,17 @@ name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+
+[[package]]
+name = "url"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+dependencies = [
+ "idna",
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "vec_map"

--- a/hermit-abi/src/lib.rs
+++ b/hermit-abi/src/lib.rs
@@ -5,6 +5,7 @@
 #![feature(const_raw_ptr_to_usize_cast)]
 extern crate libc;
 
+pub mod tcplistener;
 pub mod tcpstream;
 
 use libc::c_void;
@@ -116,6 +117,38 @@ pub struct timespec {
 	pub tv_sec: i64,
 	/// nanoseconds
 	pub tv_nsec: i64,
+}
+
+/// Internet protocol version.
+#[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+pub enum Version {
+	Unspecified,
+	Ipv4,
+	Ipv6,
+	#[doc(hidden)]
+	__Nonexhaustive,
+}
+
+/// A four-octet IPv4 address.
+#[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Default)]
+pub struct Ipv4Address(pub [u8; 4]);
+
+/// A sixteen-octet IPv6 address.
+#[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Default)]
+pub struct Ipv6Address(pub [u8; 16]);
+
+/// An internetworking address.
+#[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+pub enum IpAddress {
+	/// An unspecified address.
+	/// May be used as a placeholder for storage where the address is not assigned yet.
+	Unspecified,
+	/// An IPv4 address.
+	Ipv4(Ipv4Address),
+	/// An IPv6 address.
+	Ipv6(Ipv6Address),
+	#[doc(hidden)]
+	__Nonexhaustive,
 }
 
 /// determines the number of activated processors

--- a/hermit-abi/src/tcplistener.rs
+++ b/hermit-abi/src/tcplistener.rs
@@ -1,0 +1,13 @@
+//! `tcplistener` provide an interface to establish tcp socket server.
+
+use crate::{Handle, IpAddress};
+
+extern "Rust" {
+	fn sys_tcp_listener_accept(port: u16) -> Result<(Handle, IpAddress, u16), ()>;
+}
+
+/// Wait for connection at specified address.
+#[inline(always)]
+pub fn accept(port: u16) -> Result<(Handle, IpAddress, u16), ()> {
+	unsafe { sys_tcp_listener_accept(port) }
+}

--- a/hermit-abi/src/tcpstream.rs
+++ b/hermit-abi/src/tcpstream.rs
@@ -1,6 +1,6 @@
-//! `tcpstream` provide an interface to the network stack
+//! `tcpstream` provide an interface to establish tcp socket client.
 
-use crate::Handle;
+use crate::{Handle, IpAddress};
 
 extern "Rust" {
 	fn sys_tcp_stream_connect(ip: &[u8], port: u16, timeout: Option<u64>) -> Result<Handle, ()>;
@@ -11,12 +11,12 @@ extern "Rust" {
 	fn sys_tcp_stream_get_read_timeout(handle: Handle) -> Result<Option<u64>, ()>;
 	fn sys_tcp_stream_set_write_timeout(handle: Handle, timeout: Option<u64>) -> Result<(), ()>;
 	fn sys_tcp_stream_get_write_timeout(handle: Handle) -> Result<Option<u64>, ()>;
-	fn sys_tcp_stream_duplicate(handle: Handle) -> Result<Handle, ()>;
 	fn sys_tcp_stream_peek(handle: Handle, buf: &mut [u8]) -> Result<usize, ()>;
 	fn sys_tcp_stream_set_nonblocking(handle: Handle, mode: bool) -> Result<(), ()>;
 	fn sys_tcp_stream_set_tll(handle: Handle, ttl: u32) -> Result<(), ()>;
 	fn sys_tcp_stream_get_tll(handle: Handle) -> Result<u32, ()>;
 	fn sys_tcp_stream_shutdown(handle: Handle, how: i32) -> Result<(), ()>;
+	fn sys_tcp_stream_peer_addr(handle: Handle) -> Result<(IpAddress, u16), ()>;
 }
 
 /// Opens a TCP connection to a remote host.
@@ -32,15 +32,14 @@ pub fn close(handle: Handle) -> Result<(), ()> {
 }
 
 #[inline(always)]
-pub fn duplicate(handle: Handle) -> Result<Handle, ()> {
-	unsafe { sys_tcp_stream_duplicate(handle) }
-}
-
-#[inline(always)]
 pub fn peek(handle: Handle, buf: &mut [u8]) -> Result<usize, ()> {
 	unsafe { sys_tcp_stream_peek(handle, buf) }
 }
 
+#[inline(always)]
+pub fn peer_addr(handle: Handle) -> Result<(IpAddress, u16), ()> {
+	unsafe { sys_tcp_stream_peer_addr(handle) }
+}
 #[inline(always)]
 pub fn read(handle: Handle, buffer: &mut [u8]) -> Result<usize, ()> {
 	unsafe { sys_tcp_stream_read(handle, buffer) }

--- a/hermit-sys/src/net/mod.rs
+++ b/hermit-sys/src/net/mod.rs
@@ -10,7 +10,7 @@ use smoltcp::phy::Device;
 #[cfg(feature = "trace")]
 use smoltcp::phy::EthernetTracer;
 use smoltcp::socket::{SocketHandle, SocketSet, TcpSocket, TcpSocketBuffer, TcpState};
-use smoltcp::time::Instant;
+use smoltcp::time::{Duration, Instant};
 use smoltcp::wire::IpAddress;
 
 use crate::net::device::HermitNet;
@@ -41,6 +41,9 @@ extern "C" {
 pub type Handle = SocketHandle;
 pub type Tid = u32;
 
+/// Default keep alive interval in milliseconds
+const DEFAULT_KEEP_ALIVE_INTERVAL: u64 = 75000;
+
 static LOCAL_ENDPOINT: AtomicU16 = AtomicU16::new(0);
 
 #[derive(Debug, PartialEq, Eq)]
@@ -58,6 +61,7 @@ pub enum ReadFailed {
 #[derive(Debug, PartialEq, Eq)]
 pub enum WaitFor {
 	Establish,
+	IsActive,
 	Read,
 	Write,
 	Close,
@@ -143,6 +147,14 @@ where
 						}
 						_ => {}
 					},
+					// a thread is waiting for an active connection
+					WaitFor::IsActive => {
+						if socket.is_active() {
+							if tx.try_send(WaitForResult::Ok).is_ok() {
+								*complete = true;
+							}
+						}
+					}
 				}
 			}
 		}
@@ -168,6 +180,19 @@ where
 				LOCAL_ENDPOINT.fetch_add(1, Ordering::SeqCst),
 			)
 			.map_err(|_| ())?;
+
+		Ok(tcp_handle)
+	}
+
+	pub fn accept(&mut self, port: u16) -> Result<Handle, ()> {
+		let tcp_rx_buffer = TcpSocketBuffer::new(vec![0; 65535]);
+		let tcp_tx_buffer = TcpSocketBuffer::new(vec![0; 65535]);
+		let tcp_socket = TcpSocket::new(tcp_rx_buffer, tcp_tx_buffer);
+		let tcp_handle = self.sockets.add(tcp_socket);
+
+		// request a connection
+		let mut socket = self.sockets.get::<TcpSocket>(tcp_handle);
+		socket.listen(port).map_err(|_| ())?;
 
 		Ok(tcp_handle)
 	}
@@ -275,7 +300,14 @@ pub fn sys_tcp_stream_connect(ip: &[u8], port: u16, timeout: Option<u64>) -> Res
 		.recv_timeout(std::time::Duration::from_millis(limit))
 		.map_err(|_| ())?;
 	match result {
-		WaitForResult::Ok => Ok(handle),
+		WaitForResult::Ok => {
+			let mut guard = NIC.lock().map_err(|_| ())?;
+			let nic = guard.as_mut().ok_or(())?;
+			let mut socket = nic.sockets.get::<TcpSocket>(handle);
+			socket.set_keep_alive(Some(Duration::from_millis(DEFAULT_KEEP_ALIVE_INTERVAL)));
+
+			Ok(handle)
+		}
 		_ => Err(()),
 	}
 }
@@ -459,6 +491,10 @@ pub fn sys_tcp_stream_get_write_timeout(_handle: Handle) -> Result<Option<u64>, 
 	Err(())
 }
 
+#[deprecated(
+    since = "0.1.14",
+    note = "Please don't use this function"
+)]
 #[no_mangle]
 pub fn sys_tcp_stream_duplicate(_handle: Handle) -> Result<Handle, ()> {
 	Err(())
@@ -482,4 +518,46 @@ pub fn sys_tcp_stream_set_tll(_handle: Handle, _ttl: u32) -> Result<(), ()> {
 #[no_mangle]
 pub fn sys_tcp_stream_get_tll(_handle: Handle) -> Result<u32, ()> {
 	Err(())
+}
+
+#[no_mangle]
+pub fn sys_tcp_stream_peer_addr(handle: Handle) -> Result<(IpAddress, u16), ()> {
+	let mut guard = NIC.lock().map_err(|_| ())?;
+	let nic = guard.as_mut().ok_or(())?;
+	let mut socket = nic.sockets.get::<TcpSocket>(handle);
+	socket.set_keep_alive(Some(Duration::from_millis(DEFAULT_KEEP_ALIVE_INTERVAL)));
+	let endpoint = socket.remote_endpoint();
+
+	Ok((endpoint.addr, endpoint.port))
+}
+
+#[no_mangle]
+pub fn sys_tcp_listener_accept(port: u16) -> Result<(Handle, IpAddress, u16), ()> {
+	let (tx, rx): (Sender<WaitForResult>, Receiver<WaitForResult>) = crossbeam_channel::bounded(1);
+	let handle = {
+		let mut guard = NIC.lock().map_err(|_| ())?;
+		let nic = guard.as_mut().ok_or(())?;
+		let handle = nic.accept(port)?;
+		nic.channels.insert(handle, (WaitFor::IsActive, tx, false));
+
+		handle
+	};
+
+	unsafe {
+		sys_netwakeup();
+	}
+
+	let result = rx.recv().map_err(|_| ())?;
+	match result {
+		WaitForResult::Ok => {
+			let mut guard = NIC.lock().map_err(|_| ())?;
+			let nic = guard.as_mut().ok_or(())?;
+			let mut socket = nic.sockets.get::<TcpSocket>(handle);
+			socket.set_keep_alive(Some(Duration::from_millis(DEFAULT_KEEP_ALIVE_INTERVAL)));
+			let endpoint = socket.remote_endpoint();
+
+			Ok((handle, endpoint.addr, endpoint.port))
+		}
+		_ => Err(()),
+	}
 }

--- a/hermit-sys/src/net/mod.rs
+++ b/hermit-sys/src/net/mod.rs
@@ -491,10 +491,7 @@ pub fn sys_tcp_stream_get_write_timeout(_handle: Handle) -> Result<Option<u64>, 
 	Err(())
 }
 
-#[deprecated(
-    since = "0.1.14",
-    note = "Please don't use this function"
-)]
+#[deprecated(since = "0.1.14", note = "Please don't use this function")]
 #[no_mangle]
 pub fn sys_tcp_stream_duplicate(_handle: Handle) -> Result<Handle, ()> {
 	Err(())

--- a/httpd/Cargo.toml
+++ b/httpd/Cargo.toml
@@ -1,18 +1,21 @@
-[workspace]
-members = [
-    "hermit-abi",
-    "hermit-sys",
-    "demo",
-    "netbench",
-    "httpd",
-]
-exclude = ["target", "loader", "libhermit-rs"]
+[package]
+name = "httpd"
+authors = ["Stefan Lankes <slankes@eonerc.rwth-aachen.de>"]
+version = "0.1.0"
+edition = "2018"
+publish = false
+
+[dependencies]
+tiny_http = { git = "https://github.com/hermitcore/tiny-http.git" }
+
+[target.'cfg(all(any(target_arch = "x86_64", target_arch = "aarch64"), target_os = "hermit"))'.dependencies]
+hermit-sys = { path = "../hermit-sys", default-features = false, features = ["smoltcp", "with_submodule"] }
 
 [profile.release]
 opt-level = 3
 debug = false
 rpath = false
-lto = false
+lto = true
 debug-assertions = false
 
 [profile.dev]

--- a/httpd/src/main.rs
+++ b/httpd/src/main.rs
@@ -1,0 +1,16 @@
+/// Example is derived from tiny-http example
+/// https://github.com/tiny-http/tiny-http/blob/master/examples/hello-world.rs
+
+#[cfg(target_os = "hermit")]
+extern crate hermit_sys;
+extern crate tiny_http;
+
+fn main() {
+	let server = tiny_http::Server::http("0.0.0.0:9975").unwrap();
+	println!("Now listening on port 9975");
+
+	for rq in server.incoming_requests() {
+		let response = tiny_http::Response::from_string("hello world".to_string());
+		let _ = rq.respond(response);
+	}
+}


### PR DESCRIPTION
- add support of TcpListener of libstd
- add support of peer_addr of libstd
- add tiny web server as example
- patch depends on modifications of the Rust standard library, which are published in branch _listen_ of [hermitcore/rust](https://github.com/hermitcore/rust/tree/listen)