### PR TITLE
Add rust-toolchain file

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
It'll be convenient if you don't set `nightly` as the default toolchain.