### PR TITLE
Enable instrument feature in hermit-sys

### DIFF
--- a/hermit-sys/Cargo.toml
+++ b/hermit-sys/Cargo.toml
@@ -15,7 +15,7 @@ documentation = "https://hermitcore.github.io/rusty-hermit/hermit_sys"
 
 [features]
 # controlls whether RustyHermit is build with -Z instrument-mcount
-#instrument = ["rftrace"]
+instrument = ["rftrace"]
 trace = []
 # only for internal usage, please don't use it
 with_submodule = []
@@ -40,7 +40,7 @@ features = ["std", "ethernet", "socket-udp", "socket-tcp", "proto-ipv4", "proto-
 # to increase the output the features log and verbose should be enabled
 #features = ["log", "verbose", "std", "ethernet", "socket-udp", "socket-tcp", "proto-ipv4", "proto-ipv6"]
 
-#[dependencies.rftrace]
-#optional = true
-#features = ["backend", "buildstd", "hermit"]
-#git = "https://github.com/tlambertz/rftrace"
+[dependencies.rftrace]
+version = "0.1.0"
+optional = true
+features = ["autokernel", "buildcore", "interruptsafe"]


### PR DESCRIPTION
rftrace is now published, so we can enable it in hermit-sys's Cargo.toml again.

If you want to try it out, the easiest way is looking at the [hermitrust example](https://github.com/tlambertz/rftrace/tree/master/examples/hermitrust). You have to modify the makefile to point to a precompiled rusty-loader and virtiofsd. Then `make run` will compile and run everything and create a trace. With `make runkvm`, a trace which also records linux kvm tracepoints is created.

Full hermit+kvm trace example: [trace.tar.gz](https://github.com/hermitcore/rusty-hermit/files/4881504/trace.tar.gz), can be opened with chrome under `chrome://tracing/` or in any browser with [perfetto](https://ui.perfetto.dev/#!/viewer) (decompress first, use WASD to navigate)

