### PR TITLE
Slight Refactoring, Todos and fixmes

### DIFF
--- a/hermit-sys/src/net/mod.rs
+++ b/hermit-sys/src/net/mod.rs
@@ -315,7 +315,7 @@ fn wait_for_result(handle: Handle, timeout: Option<u64>, polling: bool) -> WaitF
 			Poll::Ready(res) => {
 				return res;
 			}
-			Poll::Pending => unsafe {
+			Poll::Pending => {
 				if let Some(t) = timeout {
 					if u128::from(t) < std::time::Instant::now().duration_since(start).as_millis() {
 						return WaitForResult::Failed;
@@ -323,8 +323,9 @@ fn wait_for_result(handle: Handle, timeout: Option<u64>, polling: bool) -> WaitF
 				}
 
 				let new_timeout = if polling { Some(0) } else { timeout };
-
-				sys_netwait(handle, new_timeout);
+				unsafe {
+					sys_netwait(handle, new_timeout);
+				}
 			},
 		}
 	}

--- a/hermit-sys/src/net/mod.rs
+++ b/hermit-sys/src/net/mod.rs
@@ -307,6 +307,7 @@ fn wait_for_result(handle: Handle, timeout: Option<u64>, polling: bool) -> WaitF
 
 	// I can do this because I know that the AsyncSocket primitive and
 	// never use the context argument.
+	// Fixme: This is UB
 	let v = MaybeUninit::uninit();
 	let mut ctx: Context = unsafe { v.assume_init() };
 


### PR DESCRIPTION
This PR is only for `src/net/mod.rs` and does the following.
- simplifies matching
- Reduce unsafe scope to the unsafe part. 
- add Fixme to the creation of the Context object. The documentation of `MaybeUninit` states the following regarding the `assume_init()` function: "It is up to the caller to guarantee that the `MaybeUninit<T>` really is in an initialized state. Calling this when the content is not yet fully initialized causes **immediate undefined behavior**." It is obviously working now, but in the future we should use a method that does not utilize UB.