### PR TITLE
Pin toolchain to specific nightly version

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,4 @@
-nightly
+[toolchain]
+channel = "nightly-2020-09-10"
+components = [ "rustfmt", "rust-src", "llvm-tools-preview"]
+targets = [ "x86_64-unknown-hermit" ]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2020-09-10"
+channel = "nightly-2020-11-25"
 components = [ "rustfmt", "rust-src", "llvm-tools-preview"]
 targets = [ "x86_64-unknown-hermit" ]


### PR DESCRIPTION
This allows us to specify a specific version and needed components in rust-toolchain that rustup can then automatically install when running e.g. `cargo build`.
This needs a release of rustup that contains https://github.com/rust-lang/rustup/pull/2438. The current version does not contain this yet, so this is PR is currently blocked (and also not tested).

Benefits:
- Pinning a specific compiler version ensures that building "always works". New nightly toolchains often can't build older versions of the rusty-hermit project
- Required toolchain components are automatically installed by rustup. 