### PR TITLE
separate basic operations (e.g. memcpy) between user & kernel space

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,6 @@
 [unstable]
 build-std = ["std", "core", "alloc", "panic_abort"]
+build-std-features = ["compiler-builtins-mem"]
 
 [build]
 target = "x86_64-unknown-hermit"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3fcd8aba10d17504c87ef12d4f62ef404c6a4703d16682a9eb5543e6cf24455"
+checksum = "7cd0782e0a7da7598164153173e5a5d4d9b1da094473c98dce0ff91406112369"
 dependencies = [
  "rustc-std-workspace-core",
 ]
@@ -256,6 +256,7 @@ dependencies = [
  "aarch64",
  "lazy_static",
  "libm",
+ "llvm-tools",
  "log",
  "rftrace",
  "smoltcp",
@@ -319,6 +320,12 @@ name = "libm"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
+
+[[package]]
+name = "llvm-tools"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955be5d0ca0465caf127165acb47964f911e2bc26073e865deb8be7189302faf"
 
 [[package]]
 name = "log"

--- a/hermit-sys/Cargo.toml
+++ b/hermit-sys/Cargo.toml
@@ -50,3 +50,4 @@ features = ["std", "ethernet", "socket-udp", "socket-tcp", "proto-ipv4", "proto-
 version = "0.1.0"
 optional = true
 features = ["autokernel", "buildcore", "interruptsafe"]
+

--- a/hermit-sys/Cargo.toml
+++ b/hermit-sys/Cargo.toml
@@ -23,6 +23,7 @@ with_submodule = []
 [build-dependencies]
 walkdir = "2"
 target_build_utils = "0.3"
+llvm-tools = { version = "0.1" }
 
 [dependencies]
 log = { version = "0.4", default-features = false }

--- a/hermit-sys/build.rs
+++ b/hermit-sys/build.rs
@@ -83,6 +83,11 @@ fn build_hermit(src_dir: &Path, target_dir_opt: Option<&Path>) {
 	};
 	println!("Lib location: {}", lib_location.display());
 
+	// in case of a debug version of the library, we have to avoid a symbol collision.
+	// Kernel and user space has its own versions of memcpy, memset, etc,
+	// Consequently, we rename the functions in the libos to avoid collisions.
+	// In addition, it provides us the offer to create a optimized version of memcpy
+	// in user space.
 	if profile == "debug" {
 		// get access to llvm tools shipped in the llvm-tools-preview rustup component
 		let llvm_tools = match llvm_tools::LlvmTools::new() {

--- a/hermit-sys/build.rs
+++ b/hermit-sys/build.rs
@@ -99,6 +99,8 @@ fn build_hermit(src_dir: &Path, target_dir_opt: Option<&Path>) {
 			}
 		};
 
+		let lib = lib_location.join("libhermit.a");
+
 		// determine llvm_objcopy
 		let llvm_objcopy = llvm_tools
 			.tool(&llvm_tools::exe("llvm-objcopy"))
@@ -116,7 +118,7 @@ fn build_hermit(src_dir: &Path, target_dir_opt: Option<&Path>) {
 			.arg("memcmp=kernel_memcmp")
 			.arg("--redefine-sym")
 			.arg("bcmp=kernel_bcmp")
-			.arg(lib_location.display().to_string() + "/libhermit.a");
+			.arg(lib.display().to_string());
 
 		println!("cmd {:?}", cmd);
 		let output = cmd.output().expect("Unable to rename symbols");

--- a/hermit-sys/build.rs
+++ b/hermit-sys/build.rs
@@ -1,3 +1,4 @@
+extern crate llvm_tools;
 extern crate target_build_utils;
 extern crate walkdir;
 
@@ -5,7 +6,7 @@ use std::env;
 use std::fs::File;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{self, Command};
 
 use target_build_utils::TargetInfo;
 use walkdir::{DirEntry, WalkDir};
@@ -80,6 +81,51 @@ fn build_hermit(src_dir: &Path, target_dir_opt: Option<&Path>) {
 	} else {
 		panic!("Try to build for an unsupported platform");
 	};
+	println!("Lib location: {}", lib_location.display());
+
+	// get access to llvm tools shipped in the llvm-tools-preview rustup component
+	let llvm_tools = match llvm_tools::LlvmTools::new() {
+		Ok(tools) => tools,
+		Err(llvm_tools::Error::NotFound) => {
+			eprintln!("Error: llvm-tools not found");
+			eprintln!("Maybe the rustup component `llvm-tools-preview` is missing?");
+			eprintln!("  Install it through: `rustup component add llvm-tools-preview`");
+			process::exit(1);
+		}
+		Err(err) => {
+			eprintln!("Failed to retrieve llvm-tools component: {:?}", err);
+			process::exit(1);
+		}
+	};
+
+	// determine llvm_objcopy
+	let llvm_objcopy = llvm_tools
+		.tool(&llvm_tools::exe("llvm-objcopy"))
+		.expect("llvm_objcopy not found in llvm-tools");
+
+	// rename symbols
+	let mut cmd = Command::new(llvm_objcopy);
+	cmd.arg("--redefine-sym")
+		.arg("memcpy=kernel_memcpy")
+		.arg("--redefine-sym")
+		.arg("memmove=kernel_memmove")
+		.arg("--redefine-sym")
+		.arg("memset=kernel_memset")
+		.arg("--redefine-sym")
+		.arg("memcmp=kernel_memcmp")
+		.arg("--redefine-sym")
+		.arg("bcmp=kernel_bcmp")
+		.arg(lib_location.display().to_string() + "/libhermit.a");
+
+	println!("cmd {:?}", cmd);
+	let output = cmd.output().expect("Unable to rename symbols");
+	let stdout = std::string::String::from_utf8(output.stdout);
+	let stderr = std::string::String::from_utf8(output.stderr);
+	println!("Rename symbols output-status: {}", output.status);
+	println!("Rename symbols output-stdout: {}", stdout.unwrap());
+	println!("Rename symbols output-stderr: {}", stderr.unwrap());
+	assert!(output.status.success());
+
 	println!("cargo:rustc-link-search=native={}", lib_location.display());
 	println!("cargo:rustc-link-lib=static=hermit");
 

--- a/hermit-sys/build.rs
+++ b/hermit-sys/build.rs
@@ -83,48 +83,50 @@ fn build_hermit(src_dir: &Path, target_dir_opt: Option<&Path>) {
 	};
 	println!("Lib location: {}", lib_location.display());
 
-	// get access to llvm tools shipped in the llvm-tools-preview rustup component
-	let llvm_tools = match llvm_tools::LlvmTools::new() {
-		Ok(tools) => tools,
-		Err(llvm_tools::Error::NotFound) => {
-			eprintln!("Error: llvm-tools not found");
-			eprintln!("Maybe the rustup component `llvm-tools-preview` is missing?");
-			eprintln!("  Install it through: `rustup component add llvm-tools-preview`");
-			process::exit(1);
-		}
-		Err(err) => {
-			eprintln!("Failed to retrieve llvm-tools component: {:?}", err);
-			process::exit(1);
-		}
-	};
+	if profile == "debug" {
+		// get access to llvm tools shipped in the llvm-tools-preview rustup component
+		let llvm_tools = match llvm_tools::LlvmTools::new() {
+			Ok(tools) => tools,
+			Err(llvm_tools::Error::NotFound) => {
+				eprintln!("Error: llvm-tools not found");
+				eprintln!("Maybe the rustup component `llvm-tools-preview` is missing?");
+				eprintln!("  Install it through: `rustup component add llvm-tools-preview`");
+				process::exit(1);
+			}
+			Err(err) => {
+				eprintln!("Failed to retrieve llvm-tools component: {:?}", err);
+				process::exit(1);
+			}
+		};
 
-	// determine llvm_objcopy
-	let llvm_objcopy = llvm_tools
-		.tool(&llvm_tools::exe("llvm-objcopy"))
-		.expect("llvm_objcopy not found in llvm-tools");
+		// determine llvm_objcopy
+		let llvm_objcopy = llvm_tools
+			.tool(&llvm_tools::exe("llvm-objcopy"))
+			.expect("llvm_objcopy not found in llvm-tools");
 
-	// rename symbols
-	let mut cmd = Command::new(llvm_objcopy);
-	cmd.arg("--redefine-sym")
-		.arg("memcpy=kernel_memcpy")
-		.arg("--redefine-sym")
-		.arg("memmove=kernel_memmove")
-		.arg("--redefine-sym")
-		.arg("memset=kernel_memset")
-		.arg("--redefine-sym")
-		.arg("memcmp=kernel_memcmp")
-		.arg("--redefine-sym")
-		.arg("bcmp=kernel_bcmp")
-		.arg(lib_location.display().to_string() + "/libhermit.a");
+		// rename symbols
+		let mut cmd = Command::new(llvm_objcopy);
+		cmd.arg("--redefine-sym")
+			.arg("memcpy=kernel_memcpy")
+			.arg("--redefine-sym")
+			.arg("memmove=kernel_memmove")
+			.arg("--redefine-sym")
+			.arg("memset=kernel_memset")
+			.arg("--redefine-sym")
+			.arg("memcmp=kernel_memcmp")
+			.arg("--redefine-sym")
+			.arg("bcmp=kernel_bcmp")
+			.arg(lib_location.display().to_string() + "/libhermit.a");
 
-	println!("cmd {:?}", cmd);
-	let output = cmd.output().expect("Unable to rename symbols");
-	let stdout = std::string::String::from_utf8(output.stdout);
-	let stderr = std::string::String::from_utf8(output.stderr);
-	println!("Rename symbols output-status: {}", output.status);
-	println!("Rename symbols output-stdout: {}", stdout.unwrap());
-	println!("Rename symbols output-stderr: {}", stderr.unwrap());
-	assert!(output.status.success());
+		println!("cmd {:?}", cmd);
+		let output = cmd.output().expect("Unable to rename symbols");
+		let stdout = std::string::String::from_utf8(output.stdout);
+		let stderr = std::string::String::from_utf8(output.stderr);
+		println!("Rename symbols output-status: {}", output.status);
+		println!("Rename symbols output-stdout: {}", stdout.unwrap());
+		println!("Rename symbols output-stderr: {}", stderr.unwrap());
+		assert!(output.status.success());
+	}
 
 	println!("cargo:rustc-link-search=native={}", lib_location.display());
 	println!("cargo:rustc-link-lib=static=hermit");


### PR DESCRIPTION
- rename symbols in libhermit to separate basic operations (e.g. memcpy) between user & kernel space
- this enables hardware-related optimizations outside the kernel space