### PR TITLE
CI: Fix windows bootloader compilation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,7 @@ jobs:
     - name: Build loader (unix)
       working-directory: loader
       run: make
+      if: ${{ ( matrix.os == 'macOS-latest' ) || ( matrix.os == 'ubuntu-latest' ) }}
     # Workaround since makefile doesn't work when using powershell
     - name: Build loader (windows)
       working-directory: loader


### PR DESCRIPTION
The windows workflow is currently broken.
The makefile shouldn't be executed with powershell, since it doesn't work. 
This line was probably forgotten in commit: https://github.com/hermitcore/rusty-hermit/commit/56eb1ab041bf15abc8ad7b89151315043fb39c9d#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88

See also libhermit-rs: https://github.com/hermitcore/libhermit-rs/blob/8ec993288a5e7e238361ffdd77d44160c48f7e22/.github/workflows/nightly.yml#L92