### PR TITLE
CI: Fix and reenable windows tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,11 +54,18 @@ jobs:
       run: |
           brew install qemu nasm
       if: ${{ matrix.os == 'macOS-latest' }}
-    - name: Install qemu/nasm (windows)
+    - name: Install nasm (windows)
       uses: crazy-max/ghaction-chocolatey@v1
       with:
-          args: install qemu nasm
+          args: install nasm
       if: ${{ matrix.os == 'windows-latest' }}
+    # Note: force version to 2020.08.14, as the november version seems to be broken.
+    - name: Install qemu (windows)
+      uses: crazy-max/ghaction-chocolatey@v1
+      with:
+          args: install qemu --version=2020.08.14
+      if: ${{ matrix.os == 'windows-latest' }}
+      # Note: The november release of qemu installs into 'C:\Program Files (x86)' by default, so keep that in mind when updating qemu
     - name: Set path to qemu/nasm (Windows)
       run: |
           echo "C:\Program Files\qemu" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
@@ -90,18 +97,14 @@ jobs:
     - name: Test dev version
       run:
          qemu-system-x86_64 -display none -smp 1 -m 64M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/debug/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr,rdrand
-      if: ${{ ( matrix.os == 'macOS-latest' ) || ( matrix.os == 'ubuntu-latest' ) }}
     - name: Test dev version (smp)
       run:
          qemu-system-x86_64 -display none -smp 2 -m 64M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/debug/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr,rdrand
       timeout-minutes: 20
-      if: ${{ ( matrix.os == 'macOS-latest' ) || ( matrix.os == 'ubuntu-latest' ) }}
     - name: Test release version
       run:
          qemu-system-x86_64 -display none -smp 1 -m 64M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/release/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr,rdrand
-      if: ${{ ( matrix.os == 'macOS-latest' ) || ( matrix.os == 'ubuntu-latest' ) }}
     - name: Test release version (smp)
       run:
          qemu-system-x86_64 -display none -smp 2 -m 64M -serial stdio -kernel loader/target/x86_64-unknown-hermit-loader/debug/rusty-loader -initrd target/x86_64-unknown-hermit/release/rusty_demo -cpu qemu64,apic,fsgsbase,rdtscp,xsave,fxsr,rdrand
       timeout-minutes: 20
-      if: ${{ ( matrix.os == 'macOS-latest' ) || ( matrix.os == 'ubuntu-latest' ) }}


### PR DESCRIPTION
- Force qemu install to latest working version
- The November 2020 release doesn't seem to be working, even when
  adjusting the path to the new install location install
  'C:\Program Files (x86)'