### PR TITLE
Allow hermit-abi to build without std

### DIFF
--- a/hermit-abi/src/lib.rs
+++ b/hermit-abi/src/lib.rs
@@ -1,8 +1,7 @@
 //! `hermit-abi` is small interface to call functions from the unikernel
 //! [RustyHermit](https://github.com/hermitcore/libhermit-rs).
 
-#![cfg_attr(feature = "rustc-dep-of-std", no_std)]
-#![feature(const_raw_ptr_to_usize_cast)]
+#![no_std]
 extern crate libc;
 
 pub mod tcplistener;


### PR DESCRIPTION
This makes crates depending on `hermit-abi` able to build by
just using `-Zbuild-std=core` instead of needing all of `-Zbuild-std`.

Also, remove an unnecessary feature that isn't used anywhere.

Signed-off-by: Joe Richey <joerichey@google.com>