### PR TITLE
revise network integration and add support of futures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,8 @@ jobs:
       - name: Install QEMU, NASM, GNU make (windows)
         if: ${{ matrix.os == 'windows-latest' }}
         run: |
-          choco install qemu nasm make
+          choco install nasm make
+          choco install qemu --version 2021.5.5
           echo "C:\Program Files\qemu" >> $GITHUB_PATH
           echo "C:\Program Files\NASM" >> $GITHUB_PATH
       - name: Build loader

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbf56136a5198c7b01a49e3afcbef6cf84597273d298f54432926024107b0109"
 
 [[package]]
+name = "async-task"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,6 +78,12 @@ name = "bytes"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad1f8e949d755f9d79112b5bb46938e0ef9d3804a0b16dfab13aafcaa5f0fa72"
+
+[[package]]
+name = "cache-padded"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
@@ -138,6 +150,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "475f939b731d862c8efe7001757c5d7c80978e00ef2923d60d90a6f0cb184c6b"
 dependencies = [
  "rustc-std-workspace-core",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+dependencies = [
+ "cache-padded",
 ]
 
 [[package]]
@@ -313,6 +334,8 @@ name = "hermit-sys"
 version = "0.1.22"
 dependencies = [
  "aarch64",
+ "async-task",
+ "concurrent-queue",
  "futures-lite",
  "lazy_static",
  "libm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,6 @@ version = "0.1.22"
 dependencies = [
  "aarch64",
  "futures",
- "futures-util",
  "lazy_static",
  "libm",
  "llvm-tools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,98 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
+name = "futures"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
+
+[[package]]
+name = "futures-task"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
+
+[[package]]
+name = "futures-util"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+ "slab",
+]
+
+[[package]]
 name = "hdrhist"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,6 +369,8 @@ name = "hermit-sys"
 version = "0.1.22"
 dependencies = [
  "aarch64",
+ "futures",
+ "futures-util",
  "lazy_static",
  "libm",
  "llvm-tools",
@@ -371,6 +465,12 @@ name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+
+[[package]]
+name = "memchr"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "memoffset"
@@ -472,6 +572,30 @@ checksum = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 dependencies = [
  "siphasher",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -778,6 +902,12 @@ name = "siphasher"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
+
+[[package]]
+name = "slab"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smoltcp"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "fastrand"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77b705829d1e87f762c2df6da140b26af5839e1033aa84aa5f56bb688e4e1bdb"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "form_urlencoded"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,46 +251,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
-name = "futures"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -290,47 +263,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
 
 [[package]]
-name = "futures-macro"
-version = "0.3.13"
+name = "futures-lite"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
+checksum = "b4481d0cd0de1d204a4fa55e7d45f07b1d958abcb06714b3446438e2eff695fb"
 dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
-
-[[package]]
-name = "futures-task"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
-
-[[package]]
-name = "futures-util"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
-dependencies = [
- "futures-channel",
+ "fastrand",
  "futures-core",
  "futures-io",
- "futures-macro",
- "futures-sink",
- "futures-task",
  "memchr",
+ "parking",
  "pin-project-lite",
- "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
- "slab",
+ "waker-fn",
 ]
 
 [[package]]
@@ -369,7 +313,7 @@ name = "hermit-sys"
 version = "0.1.22"
 dependencies = [
  "aarch64",
- "futures",
+ "futures-lite",
  "lazy_static",
  "libm",
  "llvm-tools",
@@ -399,6 +343,15 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -529,6 +482,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,24 +536,6 @@ name = "pin-project-lite"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -903,12 +844,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 
 [[package]]
-name = "slab"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
-
-[[package]]
 name = "smoltcp"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,6 +982,12 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aarch64"
-version = "0.0.4"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f59a84cc62bda7593f3c5c57f32a89492d6f4cbd9ad462019ac7c46f66c9606"
+checksum = "6270352a570bfc5f730fd1fce0c34b190c75da28e184f7e70704672a539ade77"
 dependencies = [
  "cortex-a",
 ]
@@ -38,7 +38,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi 0.1.17",
+ "hermit-abi 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
  "winapi 0.3.9",
 ]
@@ -69,15 +69,15 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1f8e949d755f9d79112b5bb46938e0ef9d3804a0b16dfab13aafcaa5f0fa72"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cache-padded"
@@ -87,15 +87,9 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
-version = "1.0.66"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
 
 [[package]]
 name = "cfg-if"
@@ -115,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "chunked_transfer"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7477065d45a8fe57167bf3cf8bcd3729b54cfcb81cca49bda2d038ea89ae82ca"
+checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "clap"
@@ -145,9 +139,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.38"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "475f939b731d862c8efe7001757c5d7c80978e00ef2923d60d90a6f0cb184c6b"
+checksum = "d69484e04eab372f5f345920e3a8c7a06e7dcbb75c0944eccdc3e3160aeee3c7"
 dependencies = [
  "rustc-std-workspace-core",
 ]
@@ -160,12 +154,6 @@ checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
 dependencies = [
  "cache-padded",
 ]
-
-[[package]]
-name = "const_fn"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
 
 [[package]]
 name = "core_affinity"
@@ -181,20 +169,20 @@ dependencies = [
 
 [[package]]
 name = "cortex-a"
-version = "3.0.5"
+version = "5.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad53da88d3deae442c1d6d3d7f3c1ba101520736e01ddb12acb17783b745aff5"
+checksum = "ecefc30975eb87afc5a810d4b2305c0ec29e607ea97e51b2ecd80766e9268d28"
 dependencies = [
  "register",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -204,19 +192,18 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.1"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
- "cfg-if 1.0.0",
- "const_fn",
+ "cfg-if",
  "crossbeam-utils",
  "lazy_static",
  "memoffset",
@@ -225,20 +212,19 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.1"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "autocfg 1.0.1",
- "cfg-if 1.0.0",
+ "cfg-if",
  "lazy_static",
 ]
 
 [[package]]
 name = "dtoa"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d7ed2934d741c6b37e33e3832298e8850b53fd2d2bea03873375596c7cea4e"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
 name = "either"
@@ -257,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
@@ -273,21 +259,21 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures-core"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
+checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
 
 [[package]]
 name = "futures-io"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
+checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
 
 [[package]]
 name = "futures-lite"
-version = "1.11.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4481d0cd0de1d204a4fa55e7d45f07b1d958abcb06714b3446438e2eff695fb"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -313,20 +299,20 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.1.19"
 dependencies = [
  "compiler_builtins",
  "libc",
  "rustc-std-workspace-core",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -359,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.0"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -374,7 +360,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -401,9 +387,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.81"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
 dependencies = [
  "rustc-std-workspace-core",
 ]
@@ -422,11 +408,11 @@ checksum = "955be5d0ca0465caf127165acb47964f911e2bc26073e865deb8be7189302faf"
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
 ]
 
 [[package]]
@@ -443,15 +429,15 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "memoffset"
-version = "0.6.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
  "autocfg 1.0.1",
 ]
@@ -500,7 +486,7 @@ version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
- "hermit-abi 0.1.17",
+ "hermit-abi 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc",
 ]
 
@@ -556,24 +542,24 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
+checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
@@ -686,20 +672,18 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "8.1.2"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fdf7d9dbd43f3d81d94a49c1c3df73cc2b3827995147e6cf7f89d4ec5483e73"
+checksum = "c27cb5785b85bd05d4eb171556c9a1a514552e26123aeae6bb7d811353148026"
 dependencies = [
  "bitflags",
- "cc",
- "rustc_version",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
 dependencies = [
  "autocfg 1.0.1",
  "crossbeam-deque",
@@ -709,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -731,9 +715,9 @@ dependencies = [
 
 [[package]]
 name = "register"
-version = "0.5.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaba5b0e477d21f61a57504bb5cef4a1e86de30300b457d38971c1cfc98b815"
+checksum = "f4a247de29ab7cc8f5006cfe775c4a81c704f9914c5e2a79696862e643135433"
 dependencies = [
  "tock-registers",
 ]
@@ -762,15 +746,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1956f5517128a2b6f23ab2dadf1a976f4f5b27962e7724c2bf3d45e539ec098c"
 
 [[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rusty_demo"
 version = "0.1.0"
 dependencies = [
@@ -797,21 +772,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-
-[[package]]
 name = "serde"
 version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,18 +779,18 @@ checksum = "34b623917345a631dc9608d5194cc206b3fe6c3554cd1c75b937e55e285254af"
 
 [[package]]
 name = "serde"
-version = "1.0.118"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
+checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.118"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
+checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -851,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc6b7951b17b051f3210b063f12cc17320e2fe30ae05b0fe2a3abb068551c76"
+checksum = "98d0516900518c29efa217c298fa1f4e6c6ffc85ae29fd7f4ee48f176e1a9ed5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -868,9 +828,9 @@ checksum = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 
 [[package]]
 name = "smoltcp"
-version = "0.7.0"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab527c390c7e107f687bd92a886a083fde61b8cdc700b37f3d7e4346ffd8fae1"
+checksum = "a4ec49aa038736b0bc852ccd9a0eadc8f7832fe8f9c8eec4e8a740b36d665614"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -885,9 +845,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.57"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4211ce9909eb971f111059df92c45640aad50a619cf55cd76476be803c4c68e6"
+checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -901,7 +861,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c15c969e3531d0506b248a095423c3a37b734cb8a214c100f7e86addec515c5"
 dependencies = [
  "cc",
- "serde 1.0.118",
+ "serde 1.0.126",
  "serde_repr",
 ]
 
@@ -939,9 +899,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf8dbc19eb42fba10e8feaaec282fb50e2c14b2726d6301dbfeed0f73306a6f"
+checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -954,24 +914,24 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tock-registers"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70323afdb8082186c0986da0e10f6e4ed103d681c921c00597e98d9806dac20f"
+checksum = "f521a79accce68c417c9c77ce22108056b626126da1932f7e2e9b5bbffee0cea"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
 dependencies = [
  "matches",
 ]
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.16"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
@@ -984,15 +944,15 @@ checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "url"
-version = "2.2.0"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1014,9 +974,9 @@ checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
 dependencies = [
  "same-file",
  "winapi 0.3.9",
@@ -1068,9 +1028,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "x86"
-version = "0.34.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c146cbc47471e076987378c159a7aa8fa434680c6fbddca59fe6f40f1591c819"
+checksum = "702d51a8a099ea6b47826796377591d2ed47116c7f0454f0d08d1d9872944880"
 dependencies = [
  "bit_field",
  "bitflags",

--- a/hermit-sys/Cargo.toml
+++ b/hermit-sys/Cargo.toml
@@ -34,8 +34,10 @@ llvm-tools = { version = "0.1" }
 
 [dependencies]
 log = { version = "0.4", default-features = false }
-lazy_static = "1.4.0"
 libm = { version = "0.2.1", default-features = false }
+futures = { version = "0.3.5" }
+futures-util = { version = "0.3.12" }
+lazy_static = "1.4"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies.x86]
 version = "0.*"
@@ -49,9 +51,9 @@ default-features = false
 version = "0.7.0"
 optional = true
 default-features = false
-features = ["std", "ethernet", "socket-udp", "socket-tcp", "proto-ipv4", "proto-ipv6"]
+features = ["std", "ethernet", "socket-udp", "socket-tcp", "proto-ipv4", "proto-ipv6", "async"]
 # to increase the output the features log and verbose should be enabled
-#features = ["log", "verbose", "std", "ethernet", "socket-udp", "socket-tcp", "proto-ipv4", "proto-ipv6"]
+#features = ["log", "verbose", "std", "ethernet", "socket-udp", "socket-tcp", "proto-ipv4", "proto-ipv6", "async"]
 
 [dependencies.rftrace]
 version = "0.1.0"

--- a/hermit-sys/Cargo.toml
+++ b/hermit-sys/Cargo.toml
@@ -35,7 +35,7 @@ llvm-tools = { version = "0.1" }
 [dependencies]
 log = { version = "0.4", default-features = false }
 libm = { version = "0.2.1", default-features = false }
-futures = { version = "0.3.5" }
+futures-lite = "1.11"
 lazy_static = "1.4"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies.x86]

--- a/hermit-sys/Cargo.toml
+++ b/hermit-sys/Cargo.toml
@@ -36,7 +36,6 @@ llvm-tools = { version = "0.1" }
 log = { version = "0.4", default-features = false }
 libm = { version = "0.2.1", default-features = false }
 futures = { version = "0.3.5" }
-futures-util = { version = "0.3.13" }
 lazy_static = "1.4"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies.x86]

--- a/hermit-sys/Cargo.toml
+++ b/hermit-sys/Cargo.toml
@@ -36,7 +36,7 @@ llvm-tools = { version = "0.1" }
 log = { version = "0.4", default-features = false }
 libm = { version = "0.2.1", default-features = false }
 futures = { version = "0.3.5" }
-futures-util = { version = "0.3.12" }
+futures-util = { version = "0.3.13" }
 lazy_static = "1.4"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies.x86]

--- a/hermit-sys/Cargo.toml
+++ b/hermit-sys/Cargo.toml
@@ -35,6 +35,8 @@ llvm-tools = { version = "0.1" }
 [dependencies]
 log = { version = "0.4", default-features = false }
 libm = { version = "0.2.1", default-features = false }
+async-task = "4.0"
+concurrent-queue = "1.2"
 futures-lite = "1.11"
 lazy_static = "1.4"
 

--- a/hermit-sys/src/lib.rs
+++ b/hermit-sys/src/lib.rs
@@ -1,3 +1,7 @@
+#![allow(clippy::mut_mutex_lock)]
+#![allow(clippy::large_enum_variant)]
+#![allow(clippy::new_ret_no_self)]
+
 #[cfg(target_arch = "aarch64")]
 extern crate aarch64;
 #[macro_use]

--- a/hermit-sys/src/net/device.rs
+++ b/hermit-sys/src/net/device.rs
@@ -96,7 +96,7 @@ impl NetworkInterface<HermitNet> {
 
 		NetworkState::Initialized(Mutex::new(Self {
 			iface,
-			sockets: sockets,
+			sockets,
 			dhcp,
 			prev_cidr,
 			waker: WakerRegistration::new(),

--- a/hermit-sys/src/net/executor.rs
+++ b/hermit-sys/src/net/executor.rs
@@ -1,7 +1,6 @@
 use crate::net::{network_delay, network_poll};
 use futures::future::BoxFuture;
 use futures::pin_mut;
-use futures::task::SpawnError;
 use smoltcp::time::{Duration, Instant};
 use std::future::Future;
 use std::sync::{
@@ -43,9 +42,8 @@ impl SmoltcpExecutor {
 		Self { pool: Vec::new() }
 	}
 
-	fn spawn_obj(&mut self, future: BoxFuture<'static, ()>) -> Result<(), SpawnError> {
+	fn spawn_obj(&mut self, future: BoxFuture<'static, ()>) {
 		self.pool.push(future);
-		Ok(())
 	}
 }
 
@@ -146,6 +144,6 @@ pub fn block_on<F: Future>(f: F, timeout: Option<Duration>) -> Result<F::Output,
 	run_until(|cx| f.as_mut().poll(cx), timeout)
 }
 
-pub fn spawn<F: Future<Output = ()> + std::marker::Send + 'static>(f: F) -> Result<(), SpawnError> {
+pub fn spawn<F: Future<Output = ()> + std::marker::Send + 'static>(f: F) {
 	EXECUTOR.lock().unwrap().spawn_obj(Box::pin(f))
 }

--- a/hermit-sys/src/net/executor.rs
+++ b/hermit-sys/src/net/executor.rs
@@ -18,7 +18,6 @@ extern "C" {
 	fn sys_getpid() -> Tid;
 	fn sys_yield();
 	fn sys_wakeup_task(tid: Tid);
-	fn sys_set_network_polling_mode(value: bool);
 	fn sys_block_current_task_with_timeout(timeout: u64);
 	fn sys_block_current_task();
 }
@@ -93,7 +92,6 @@ where
 	}
 
 	CURRENT_THREAD_NOTIFY.with(|thread_notify| {
-		unsafe { sys_set_network_polling_mode(true) }
 		let start = Instant::now();
 
 		let waker = thread_notify.clone().into();
@@ -101,13 +99,11 @@ where
 		pin!(future);
 		loop {
 			if let Poll::Ready(t) = future.as_mut().poll(&mut cx) {
-				unsafe { sys_set_network_polling_mode(false) }
 				return Ok(t);
 			}
 
 			if let Some(duration) = timeout {
 				if Instant::now() >= start + duration {
-					unsafe { sys_set_network_polling_mode(false) }
 					return Err(());
 				}
 			}
@@ -118,13 +114,11 @@ where
 				let unparked = thread_notify.unparked.swap(false, Ordering::Acquire);
 				if !unparked {
 					unsafe {
-						sys_set_network_polling_mode(false);
 						match delay {
 							Some(d) => sys_block_current_task_with_timeout(d),
 							None => sys_block_current_task(),
 						};
 						sys_yield();
-						sys_set_network_polling_mode(true);
 					}
 					thread_notify.unparked.store(false, Ordering::Release);
 					run_executor()

--- a/hermit-sys/src/net/executor.rs
+++ b/hermit-sys/src/net/executor.rs
@@ -1,0 +1,202 @@
+use crate::net::{network_delay, network_poll};
+use futures::task::{waker_ref, ArcWake, FutureObj, SpawnError};
+use futures_util::pin_mut;
+use smoltcp::time::{Duration, Instant};
+use std::future::Future;
+use std::sync::{
+	atomic::{AtomicBool, AtomicUsize, Ordering},
+	Arc, Mutex,
+};
+use std::task::{Context, Poll};
+
+/// A thread handle type
+type Tid = u32;
+
+extern "C" {
+	fn sys_getpid() -> u32;
+	fn sys_yield();
+	fn sys_wakeup_task(tid: Tid);
+	fn sys_set_network_polling_mode(value: bool);
+}
+
+extern "Rust" {
+	fn sys_block_current_task_with_timeout(timeout: Option<u64>);
+}
+
+thread_local! {
+	static CURRENT_THREAD_NOTIFY: Arc<ThreadNotify> = {
+		Arc::new(ThreadNotify::new())
+	}
+}
+
+lazy_static! {
+	static ref EXECUTOR: Mutex<SmoltcpExecutor> = Mutex::new(SmoltcpExecutor::new());
+}
+
+static NTHREADS_IN_EXECUTOR: ThreadsInExecutor = ThreadsInExecutor::new();
+
+struct SmoltcpExecutor {
+	pool: Vec<FutureObj<'static, ()>>,
+}
+
+impl SmoltcpExecutor {
+	pub const fn new() -> Self {
+		Self { pool: Vec::new() }
+	}
+
+	fn spawn_obj(&mut self, future: FutureObj<'static, ()>) -> Result<(), SpawnError> {
+		self.pool.push(future);
+		Ok(())
+	}
+}
+
+/// Helper struct to determine, if the network interface
+/// has to set in polling mode and to disable interrupts
+/// from the network interface.
+struct ThreadsInExecutor {
+	/// number of threads in the executor
+	nthreads: AtomicUsize,
+	/// number of blocked threads
+	blocked: AtomicUsize,
+}
+
+impl ThreadsInExecutor {
+	pub const fn new() -> Self {
+		Self {
+			nthreads: AtomicUsize::new(0),
+			blocked: AtomicUsize::new(0),
+		}
+	}
+
+	pub fn increment(&self) {
+		let old = self.nthreads.fetch_add(1, Ordering::SeqCst);
+		if old + 1 > self.blocked.load(Ordering::SeqCst) {
+			// a thread is waiting for message
+			unsafe {
+				sys_set_network_polling_mode(true);
+			}
+		}
+	}
+
+	pub fn decrement(&self) {
+		let old = self.nthreads.fetch_sub(1, Ordering::SeqCst);
+		if old - 1 <= self.blocked.load(Ordering::SeqCst) {
+			// no thread is waiting for a message
+			unsafe {
+				sys_set_network_polling_mode(false);
+			}
+		}
+	}
+
+	pub fn unblock(&self) {
+		let old = self.blocked.fetch_sub(1, Ordering::SeqCst);
+		if self.nthreads.load(Ordering::SeqCst) > old - 1 {
+			// a thread is waiting for message
+			unsafe {
+				sys_set_network_polling_mode(true);
+			}
+		}
+	}
+
+	pub fn block(&self) {
+		let old = self.blocked.fetch_add(1, Ordering::SeqCst);
+		if self.nthreads.load(Ordering::SeqCst) <= old + 1 {
+			// no thread is waiting for a message
+			unsafe {
+				sys_set_network_polling_mode(false);
+			}
+		}
+	}
+}
+
+struct ThreadNotify {
+	/// The (single) executor thread.
+	thread: Tid,
+	/// A flag to ensure a wakeup is not "forgotten" before the next `block_current_task`
+	unparked: AtomicBool,
+}
+
+impl ThreadNotify {
+	pub fn new() -> Self {
+		Self {
+			thread: unsafe { sys_getpid() },
+			unparked: AtomicBool::new(false),
+		}
+	}
+}
+
+impl Drop for ThreadNotify {
+	fn drop(&mut self) {
+		println!("Dropping ThreadNotify!");
+	}
+}
+
+impl ArcWake for ThreadNotify {
+	fn wake_by_ref(arc_self: &Arc<Self>) {
+		// Make sure the wakeup is remembered until the next `park()`.
+		let unparked = arc_self.unparked.swap(true, Ordering::Relaxed);
+		if !unparked {
+			unsafe {
+				sys_wakeup_task(arc_self.thread);
+			}
+		}
+	}
+}
+
+// Set up and run a basic single-threaded spawner loop, invoking `f` on each
+// turn.
+fn run_until<T, F: FnMut(&mut Context<'_>) -> Poll<T>>(
+	mut f: F,
+	timeout: Option<Duration>,
+) -> Result<T, ()> {
+	NTHREADS_IN_EXECUTOR.increment();
+	let start = Instant::now();
+
+	CURRENT_THREAD_NOTIFY.with(|thread_notify| {
+		let waker = waker_ref(thread_notify);
+		let mut cx = Context::from_waker(&waker);
+		loop {
+			if let Poll::Ready(t) = f(&mut cx) {
+				NTHREADS_IN_EXECUTOR.decrement();
+				return Ok(t);
+			}
+
+			if let Some(duration) = timeout {
+				if Instant::now() >= start + duration {
+					NTHREADS_IN_EXECUTOR.decrement();
+					return Err(());
+				}
+			} else {
+				let timestamp = Instant::now();
+				let delay = network_delay(timestamp).map(|d| d.total_millis());
+
+				if delay.is_none() || delay.unwrap() > 200 {
+					let unparked = thread_notify.unparked.swap(false, Ordering::Acquire);
+					if !unparked {
+						NTHREADS_IN_EXECUTOR.block();
+						unsafe {
+							sys_block_current_task_with_timeout(delay);
+							sys_yield();
+						}
+						NTHREADS_IN_EXECUTOR.unblock();
+						thread_notify.unparked.store(false, Ordering::Release);
+					}
+				} else {
+					network_poll(&mut cx, timestamp);
+				}
+			}
+		}
+	})
+}
+
+pub fn block_on<F: Future>(f: F, timeout: Option<Duration>) -> Result<F::Output, ()> {
+	pin_mut!(f);
+	run_until(|cx| f.as_mut().poll(cx), timeout)
+}
+
+pub fn spawn<F: Future<Output = ()> + std::marker::Send + 'static>(f: F) -> Result<(), SpawnError> {
+	EXECUTOR
+		.lock()
+		.unwrap()
+		.spawn_obj(FutureObj::from(Box::new(f)))
+}

--- a/hermit-sys/src/net/executor.rs
+++ b/hermit-sys/src/net/executor.rs
@@ -13,7 +13,7 @@ use std::task::{Context, Poll, Wake};
 type Tid = u32;
 
 extern "C" {
-	fn sys_getpid() -> u32;
+	fn sys_getpid() -> Tid;
 	fn sys_yield();
 	fn sys_wakeup_task(tid: Tid);
 	fn sys_set_network_polling_mode(value: bool);

--- a/hermit-sys/src/net/executor.rs
+++ b/hermit-sys/src/net/executor.rs
@@ -91,7 +91,6 @@ pub fn poll_on<F, T>(future: F, timeout: Option<Duration>) -> Result<T, ()>
 where
 	F: Future<Output = T>,
 {
-	info!("II");
 	CURRENT_THREAD_NOTIFY.with(|thread_notify| {
 		unsafe {
 			sys_set_network_polling_mode(true);
@@ -107,7 +106,6 @@ where
 				unsafe {
 					sys_set_network_polling_mode(false);
 				}
-				info!("JJ");
 				return Ok(t);
 			}
 

--- a/hermit-sys/src/net/executor.rs
+++ b/hermit-sys/src/net/executor.rs
@@ -1,6 +1,6 @@
 use crate::net::{network_delay, network_poll};
+use futures::pin_mut;
 use futures::task::{waker_ref, ArcWake, FutureObj, SpawnError};
-use futures_util::pin_mut;
 use smoltcp::time::{Duration, Instant};
 use std::future::Future;
 use std::sync::{

--- a/hermit-sys/src/net/mod.rs
+++ b/hermit-sys/src/net/mod.rs
@@ -29,7 +29,7 @@ use smoltcp::Error;
 use futures_lite::future;
 
 use crate::net::device::HermitNet;
-use crate::net::executor::{block_on, spawn};
+use crate::net::executor::{block_on, poll_on, spawn};
 use crate::net::waker::WakerRegistration;
 
 pub(crate) enum NetworkState {
@@ -415,13 +415,13 @@ pub fn sys_tcp_stream_connect(ip: &[u8], port: u16, timeout: Option<u64>) -> Res
 #[no_mangle]
 pub fn sys_tcp_stream_read(handle: Handle, buffer: &mut [u8]) -> Result<usize, ()> {
 	let socket = AsyncSocket::from(handle);
-	block_on(socket.read(buffer), None)?.map_err(|_| ())
+	poll_on(socket.read(buffer), None)?.map_err(|_| ())
 }
 
 #[no_mangle]
 pub fn sys_tcp_stream_write(handle: Handle, buffer: &[u8]) -> Result<usize, ()> {
 	let socket = AsyncSocket::from(handle);
-	block_on(socket.write(buffer), None)?.map_err(|_| ())
+	poll_on(socket.write(buffer), None)?.map_err(|_| ())
 }
 
 #[no_mangle]

--- a/hermit-sys/src/net/mod.rs
+++ b/hermit-sys/src/net/mod.rs
@@ -410,7 +410,7 @@ pub(crate) fn network_init() -> Result<(), ()> {
 					debug!("Spawn network thread with id {}", tid);
 				}
 
-				spawn(network_run()).map_err(|_| ())?;
+				spawn(network_run());
 
 				// switch to network thread
 				sys_yield();

--- a/hermit-sys/src/net/mod.rs
+++ b/hermit-sys/src/net/mod.rs
@@ -351,13 +351,6 @@ fn start_endpoint() -> u16 {
 	(CNTPCT_EL0.get() % (u16::MAX as u64)).try_into().unwrap()
 }
 
-pub(crate) fn network_poll(cx: &mut Context<'_>, timestamp: Instant) {
-	match unsafe { &mut NIC } {
-		NetworkState::Initialized(nic) => nic.lock().unwrap().poll(cx, timestamp),
-		_ => (),
-	}
-}
-
 pub(crate) fn network_delay(timestamp: Instant) -> Option<Duration> {
 	match unsafe { &mut NIC } {
 		NetworkState::Initialized(nic) => nic.lock().unwrap().poll_delay(timestamp),
@@ -412,7 +405,7 @@ pub(crate) fn network_init() -> Result<(), ()> {
 					debug!("Spawn network thread with id {}", tid);
 				}
 
-				spawn(network_run());
+				spawn(network_run()).detach();
 
 				// switch to network thread
 				sys_yield();

--- a/hermit-sys/src/net/mod.rs
+++ b/hermit-sys/src/net/mod.rs
@@ -409,11 +409,7 @@ pub(crate) fn network_init() -> Result<(), ()> {
 #[no_mangle]
 pub fn sys_tcp_stream_connect(ip: &[u8], port: u16, timeout: Option<u64>) -> Result<Handle, ()> {
 	let socket = AsyncSocket::new();
-	block_on(
-		socket.connect(ip, port),
-		timeout.map(Duration::from_millis),
-	)?
-	.map_err(|_| ())
+	block_on(socket.connect(ip, port), timeout.map(Duration::from_millis))?.map_err(|_| ())
 }
 
 #[no_mangle]

--- a/hermit-sys/src/net/mod.rs
+++ b/hermit-sys/src/net/mod.rs
@@ -187,15 +187,12 @@ impl AsyncSocket {
 		let address = IpAddress::from_str(std::str::from_utf8(ip).map_err(|_| Error::Illegal)?)
 			.map_err(|_| Error::Illegal)?;
 
-		future::poll_fn(|_| {
-			self.with(|s| {
-				Poll::Ready(s.connect(
-					(address, port),
-					LOCAL_ENDPOINT.fetch_add(1, Ordering::SeqCst),
-				))
-			})
+		self.with(|s| {
+			s.connect(
+				(address, port),
+				LOCAL_ENDPOINT.fetch_add(1, Ordering::SeqCst),
+			)
 		})
-		.await
 		.map_err(|_| Error::Illegal)?;
 
 		future::poll_fn(|cx| {

--- a/hermit-sys/src/net/mod.rs
+++ b/hermit-sys/src/net/mod.rs
@@ -254,10 +254,8 @@ impl AsyncSocket {
 				| TcpState::Closing
 				| TcpState::TimeWait => Poll::Ready(Err(Error::Illegal)),
 				_ => {
-					if s.can_recv() {
+					if s.may_recv() {
 						Poll::Ready(s.recv_slice(buffer))
-					} else if !s.may_recv() {
-						Poll::Ready(Err(Error::Illegal))
 					} else {
 						s.register_recv_waker(cx.waker());
 						Poll::Pending

--- a/hermit-sys/src/net/waker.rs
+++ b/hermit-sys/src/net/waker.rs
@@ -1,0 +1,44 @@
+/// The waker registration is derived from smoltcp waker registration
+use core::task::Waker;
+
+/// Utility struct to register and wake a waker.
+#[derive(Debug)]
+pub(crate) struct WakerRegistration {
+	waker: Option<Waker>,
+}
+
+impl WakerRegistration {
+	pub(crate) const fn new() -> Self {
+		Self { waker: None }
+	}
+
+	/// Register a waker. Overwrites the previous waker, if any.
+	pub(crate) fn register(&mut self, w: &Waker) {
+		match self.waker {
+			// Optimization: If both the old and new Wakers wake the same task, we can simply
+			// keep the old waker, skipping the clone. (In most executor implementations,
+			// cloning a waker is somewhat expensive, comparable to cloning an Arc).
+			Some(ref w2) if (w2.will_wake(w)) => {}
+			_ => {
+				// clone the new waker and store it
+				if let Some(old_waker) = std::mem::replace(&mut self.waker, Some(w.clone())) {
+					// We had a waker registered for another task. Wake it, so the other task can
+					// reregister itself if it's still interested.
+					//
+					// If two tasks are waiting on the same thing concurrently, this will cause them
+					// to wake each other in a loop fighting over this WakerRegistration. This wastes
+					// CPU but things will still work.
+					//
+					// If the user wants to have two tasks waiting on the same thing they should use
+					// a more appropriate primitive that can store multiple wakers.
+					old_waker.wake()
+				}
+			}
+		}
+	}
+
+	/// Wake the registered waker, if any.
+	pub(crate) fn wake(&mut self) {
+		self.waker.take().map(|w| w.wake());
+	}
+}

--- a/hermit-sys/src/net/waker.rs
+++ b/hermit-sys/src/net/waker.rs
@@ -39,6 +39,8 @@ impl WakerRegistration {
 
 	/// Wake the registered waker, if any.
 	pub(crate) fn wake(&mut self) {
-		self.waker.take().map(|w| w.wake());
+		if let Some(w) = self.waker.take() {
+			w.wake();
+		}
 	}
 }


### PR DESCRIPTION
smoltcp 0.7 provides async/await waker support (https://github.com/smoltcp-rs/smoltcp/pull/394).
I followed the example implementation https://github.com/embassy-rs/embassy/tree/net/embassy-net
to add waker support in hermit-sys.

However, hermit-sys can be used in a multi-threaded applications.
Consequently, the implementation must be thread safed. In addition,
we still have an "network thread", which is wakeup by an interrupt.
The thread wakeups all waiting future. If no future is available,
the thread calls directly the IP stack.