### PR TITLE
rename target to build libos

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,27 +9,26 @@ variables:
   DOCKER_FILE: Dockerfile
   DOCKER_TAG: latest
   DOCKER_IMAGE: ${CI_REGISTRY_IMAGE}
+  IMAGE: ${CI_REGISTRY_IMAGE}
   GIT_SUBMODULE_STRATEGY: normal
   FF_GITLAB_REGISTRY_HELPER_IMAGE: 1
 
 .prepare:docker: &prepare_docker
   stage: prepare
   image:
-    name: quay.io/buildah/stable
+    name: docker
   variables:
     _BUILDAH_STARTED_IN_USERNS: ""
     BUILDAH_ISOLATION: chroot
     BUILDAH_LAYERS: "true"
   before_script:
-  - buildah version
-  - buildah login --username "${CI_REGISTRY_USER}" --password "${CI_REGISTRY_PASSWORD}" "${CI_REGISTRY}"
+  - docker version
+  - docker login --username "${CI_REGISTRY_USER}" --password "${CI_REGISTRY_PASSWORD}" "${CI_REGISTRY}"
   script:
-  - buildah bud -f ${DOCKER_FILE} -t ${DOCKER_IMAGE}:${DOCKER_TAG} .
-  - buildah push ${DOCKER_IMAGE}:${DOCKER_TAG} docker://${DOCKER_IMAGE}:${DOCKER_TAG}
-  after_script:
-  - buildah logout "${CI_REGISTRY}"
+  - docker build -f ${DOCKER_FILE} -t ${DOCKER_IMAGE}:${DOCKER_TAG} .
+  - docker push ${DOCKER_IMAGE}:${DOCKER_TAG}
   tags:
-  - builder
+  - docker
 
 prepare:docker:
   <<: *prepare_docker

--- a/hermit-sys/build.rs
+++ b/hermit-sys/build.rs
@@ -23,7 +23,7 @@ fn build_hermit(src_dir: &Path, target_dir_opt: Option<&Path>) {
 			.arg("-Z")
 			.arg("build-std=core,alloc")
 			.arg("--target")
-			.arg("x86_64-unknown-hermit-kernel");
+			.arg("x86_64-unknown-none-hermitkernel");
 	} else if target.target_arch() == "aarch64" {
 		cmd.current_dir(src_dir)
 			.arg("build")
@@ -108,7 +108,7 @@ fn build_hermit(src_dir: &Path, target_dir_opt: Option<&Path>) {
 
 	let lib_location = if target.target_arch() == "x86_64" {
 		target_dir
-			.join("x86_64-unknown-hermit-kernel")
+			.join("x86_64-unknown-none-hermitkernel")
 			.join(&profile)
 			.canonicalize()
 			.unwrap() // Must exist after building

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2021-02-11"
+channel = "nightly-2021-04-20"
 components = [ "rustfmt", "rust-src", "llvm-tools-preview"]
 targets = [ "x86_64-unknown-hermit" ]


### PR DESCRIPTION
- rename target to build libos
- add latest supported toolchain as default toolchain