### PR TITLE
enable LTO support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,5 @@ opt-level = 1      # controls the `--opt-level` the compiler builds with
 debug = true       # controls whether the compiler passes `-C debuginfo`
                    # a value of `true` is equivalent to `2`
 rpath = false      # controls whether the compiler passes `-C rpath`
-lto = false         # controls `-C lto` for binaries and staticlibs
+lto = true         # controls `-C lto` for binaries and staticlibs
 debug-assertions = true # controls whether debug assertions are enabled

--- a/README.md
+++ b/README.md
@@ -152,24 +152,6 @@ qemu-system-x86_64 ... -append "kernel-arguments -- application-arguments"
 
 You are not happy with `Hello World` yet?
 
-### Link Time Optimization (LTO)
-
-To enable *Link Time Optimization* (LTO), please extend the release configuration in *Cargo.toml* as follows:
-
-```toml
-# Cargo.toml
-[profile.release]
-opt-level = 3
-lto = "thin"
-```
-
-In addition, the [Linker-plugin LTO](https://doc.rust-lang.org/rustc/linker-plugin-lto.html) have to be enabled by setting the compiler flag `linker-plugin-lto`.
-In this case, the release version have to build as follows:
-
-```sh
-RUSTFLAGS="-Clinker-plugin-lto" cargo build -Z build-std=std,core,alloc,panic_abort --target x86_64-unknown-hermit --release
-```
-
 ### Controlling kernel message verbosity
 
 RustyHermit uses the lightweight logging crate [log](https://github.com/rust-lang/log) to print kernel messages.

--- a/benches/micro/Cargo.toml
+++ b/benches/micro/Cargo.toml
@@ -41,5 +41,5 @@ opt-level = 1      # controls the `--opt-level` the compiler builds with
 debug = true       # controls whether the compiler passes `-C debuginfo`
                    # a value of `true` is equivalent to `2`
 rpath = false      # controls whether the compiler passes `-C rpath`
-lto = false         # controls `-C lto` for binaries and staticlibs
+lto = true         # controls `-C lto` for binaries and staticlibs
 debug-assertions = true # controls whether debug assertions are enabled

--- a/benches/netbench/Cargo.toml
+++ b/benches/netbench/Cargo.toml
@@ -57,5 +57,5 @@ opt-level = 1      # controls the `--opt-level` the compiler builds with
 debug = true       # controls whether the compiler passes `-C debuginfo`
                    # a value of `true` is equivalent to `2`
 rpath = false      # controls whether the compiler passes `-C rpath`
-lto = false         # controls `-C lto` for binaries and staticlibs
+lto = true         # controls `-C lto` for binaries and staticlibs
 debug-assertions = true # controls whether debug assertions are enabled

--- a/examples/demo/Cargo.toml
+++ b/examples/demo/Cargo.toml
@@ -54,5 +54,5 @@ opt-level = 1      # controls the `--opt-level` the compiler builds with
 debug = true       # controls whether the compiler passes `-C debuginfo`
                    # a value of `true` is equivalent to `2`
 rpath = false      # controls whether the compiler passes `-C rpath`
-lto = false         # controls `-C lto` for binaries and staticlibs
+lto = true         # controls `-C lto` for binaries and staticlibs
 debug-assertions = true # controls whether debug assertions are enabled

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -31,5 +31,5 @@ opt-level = 1      # controls the `--opt-level` the compiler builds with
 debug = true       # controls whether the compiler passes `-C debuginfo`
                    # a value of `true` is equivalent to `2`
 rpath = false      # controls whether the compiler passes `-C rpath`
-lto = false         # controls `-C lto` for binaries and staticlibs
+lto = true         # controls `-C lto` for binaries and staticlibs
 debug-assertions = true # controls whether debug assertions are enabled

--- a/examples/httpd/Cargo.toml
+++ b/examples/httpd/Cargo.toml
@@ -37,5 +37,5 @@ opt-level = 1      # controls the `--opt-level` the compiler builds with
 debug = true       # controls whether the compiler passes `-C debuginfo`
                    # a value of `true` is equivalent to `2`
 rpath = false      # controls whether the compiler passes `-C rpath`
-lto = false         # controls `-C lto` for binaries and staticlibs
+lto = true         # controls `-C lto` for binaries and staticlibs
 debug-assertions = true # controls whether debug assertions are enabled


### PR DESCRIPTION
This PR enable link-time-optimizations. However, this remains disabled in libhermit, otherwise the linker uses SSE/AVX instruction in the kernel, which isn't allowed.

This PR solves issue #125.