### PR TITLE
[DO NOT MERGE] Revert to last nightly with working network

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2021-05-19"
+channel = "nightly-2021-03-22"
 components = [ "rustfmt", "rust-src", "llvm-tools-preview"]
 targets = [ "x86_64-unknown-hermit" ]


### PR DESCRIPTION
This demonstrates the last working state without #128.

Do not merge! This is merely used to find the real cause for #128.