### PR TITLE
Don't override kernel panic/oom handlers in userspace

### DIFF
--- a/hermit-sys/build.rs
+++ b/hermit-sys/build.rs
@@ -191,12 +191,13 @@ fn rename_symbol(symbol: impl AsRef<OsStr>, lib: impl AsRef<Path>) {
 	// Rename symbols
 	let arg = IntoIterator::into_iter([symbol.as_ref(), "=kernel-".as_ref(), symbol.as_ref()])
 		.collect::<OsString>();
-	Command::new(llvm_objcopy)
+	let status = Command::new(llvm_objcopy)
 		.arg("--redefine-sym")
 		.arg(arg)
 		.arg(lib.as_ref())
 		.status()
-		.expect("Unable to rename symbols");
+		.expect("failed to execute llvm-objcopy");
+	assert!(status.success(), "llvm-objcopy was not sucessful");
 }
 
 #[cfg(all(not(feature = "rustc-dep-of-std"), not(feature = "with_submodule")))]


### PR DESCRIPTION
Fixes https://github.com/hermitcore/libhermit-rs/issues/43.

`std`'s panic handler in userspace seems to do weird stuff that leads to page faults instead of a proper panic. This fixes the issue by renaming the kernel handler symbols making both coexist.