### PR TITLE
correct repository URL for hermit-abi

### DIFF
--- a/hermit-abi/Cargo.toml
+++ b/hermit-abi/Cargo.toml
@@ -9,7 +9,7 @@ description = """
 hermit-abi is small interface to call functions from the unikernel RustyHermit.
 It is used to build the target `x86_64-unknown-hermit`.
 """
-repository = "https://github.com/hermitcore/libhermit-rs"
+repository = "https://github.com/hermitcore/rusty-hermit"
 keywords = ["unikernel", "libos"]
 categories = ["os"]
 documentation = "https://hermitcore.github.io/rusty-hermit/hermit_abi"


### PR DESCRIPTION
The `hermit-abi` package actually lives in the rusty-hermit repository and not in the libhermit-rs repository.