### PR TITLE
Make NIC not mut anymore

### DIFF
--- a/hermit-sys/src/lib.rs
+++ b/hermit-sys/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::mut_mutex_lock)]
 #![allow(clippy::large_enum_variant)]
 #![allow(clippy::new_ret_no_self)]
 

--- a/hermit-sys/src/net/device.rs
+++ b/hermit-sys/src/net/device.rs
@@ -7,7 +7,6 @@ use std::convert::TryInto;
 #[cfg(not(feature = "dhcpv4"))]
 use std::net::Ipv4Addr;
 use std::slice;
-use std::sync::Mutex;
 
 #[cfg(feature = "dhcpv4")]
 use smoltcp::dhcp::Dhcpv4Client;
@@ -94,13 +93,13 @@ impl NetworkInterface<HermitNet> {
 			.routes(routes)
 			.finalize();
 
-		NetworkState::Initialized(Mutex::new(Self {
+		NetworkState::Initialized(Self {
 			iface,
 			sockets,
 			dhcp,
 			prev_cidr,
 			waker: WakerRegistration::new(),
-		}))
+		})
 	}
 
 	#[cfg(not(feature = "dhcpv4"))]
@@ -168,11 +167,11 @@ impl NetworkInterface<HermitNet> {
 			.routes(routes)
 			.finalize();
 
-		NetworkState::Initialized(Mutex::new(Self {
+		NetworkState::Initialized(Self {
 			iface,
 			sockets: SocketSet::new(vec![]),
 			waker: WakerRegistration::new(),
-		}))
+		})
 	}
 }
 


### PR DESCRIPTION
This moves the Mutex outside NetworkState, avoiding the `static mut` and properly locking the whole network state on access.

This considerably reduces unsafe code.

What do you think?