### PR TITLE
Fix crash on empty `CARGO_ENCODED_RUSTFLAGS`

### DIFF
--- a/hermit-sys/build.rs
+++ b/hermit-sys/build.rs
@@ -98,7 +98,7 @@ fn build_hermit(src_dir: &Path, target_dir_opt: Option<&Path>) {
 	}
 
 	let mut rustflags = vec!["-Zmutable-noalias=no".to_string()];
-	let outer_rustflags = env::var("CARGO_ENCODED_RUSTFLAGS").unwrap();
+	let outer_rustflags = env::var("CARGO_ENCODED_RUSTFLAGS").unwrap_or_default();
 
 	#[cfg(feature = "instrument")]
 	{


### PR DESCRIPTION
On build I got this error:
```
error: failed to run custom build command for `hermit-sys v0.1.24`

Caused by:
  process didn't exit successfully: `/Users/qtmsheep/Development/rusty-hermit/target/debug/build/hermit-sys-8d3bf800916ebc23/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=HERMIT_IP
  cargo:rerun-if-env-changed=HERMIT_GATEWAY
  cargo:rerun-if-env-changed=HERMIT_MASK

  --- stderr
  INFO: cargo-download v0.1.2
  INFO: Latest version of crate rusty-hermit=* is 0.3.53
  INFO: Crate `rusty-hermit==0.3.53` downloaded successfully
  INFO: Crate content extracted to /Users/qtmsheep/Development/rusty-hermit/target/x86_64-unknown-hermit/debug/build/hermit-sys-e3376232ce6852bd/out/rusty-hermit/
  thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: NotPresent', /Users/qtmsheep/.cargo/registry/src/github.com-1ecc6299db9ec823/hermit-sys-0.1.24/build.rs:101:63
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Defaulting to an empty string resolves the issue.