### PR TITLE
Upgrade to Rust 2021 

### DIFF
--- a/benches/micro/Cargo.toml
+++ b/benches/micro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "micro_benchmarks"
 version = "0.1.0"
 authors = ["Stefan Lankes <slankes@eonerc.rwth-aachen.de>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/benches/netbench/Cargo.toml
+++ b/benches/netbench/Cargo.toml
@@ -3,7 +3,7 @@
 name = "rust-tcp-io-perf"
 version = "0.0.0"
 authors = ["Lorenzo Martini <lmartini@student.ethz.ch>"]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 
 description = "A Rust program to measure bandwidth or latency over a Rust TCP connection"

--- a/examples/demo/Cargo.toml
+++ b/examples/demo/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rusty_demo"
 version = "0.1.0"
 authors = ["Stefan Lankes <slankes@eonerc.rwth-aachen.de>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [[bin]]

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hello_world"
 version = "0.1.0"
 authors = ["Stefan Lankes <slankes@eonerc.rwth-aachen.de>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [target.'cfg(all(any(target_arch = "x86_64", target_arch = "aarch64"), target_os = "hermit"))'.dependencies.hermit-sys]

--- a/examples/httpd/Cargo.toml
+++ b/examples/httpd/Cargo.toml
@@ -2,7 +2,7 @@
 name = "httpd"
 authors = ["Stefan Lankes <slankes@eonerc.rwth-aachen.de>"]
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/hermit-abi/Cargo.toml
+++ b/hermit-abi/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.19"
 authors = ["Stefan Lankes"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 description = """
 hermit-abi is small interface to call functions from the unikernel RustyHermit.
 It is used to build the target `x86_64-unknown-hermit`.

--- a/hermit-sys/Cargo.toml
+++ b/hermit-sys/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["unikernel", "libos"]
 categories = ["os"]
 links = "hermit"
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 documentation = "https://hermitcore.github.io/rusty-hermit/hermit_sys"
 
 [features]

--- a/hermit-sys/build.rs
+++ b/hermit-sys/build.rs
@@ -256,7 +256,7 @@ fn configure_cargo_rerun_if_changed(src_dir: &Path) {
 
 	WalkDir::new(src_dir)
 		.into_iter()
-		.filter_entry(|e| is_not_ignored(e))
+		.filter_entry(is_not_ignored)
 		.filter_map(|v| v.ok())
 		.filter_map(|v| v.path().canonicalize().ok())
 		.for_each(|x| println!("cargo:rerun-if-changed={}", x.display()));

--- a/hermit-sys/src/net/device.rs
+++ b/hermit-sys/src/net/device.rs
@@ -3,8 +3,6 @@ include!(concat!(env!("OUT_DIR"), "/constants.rs"));
 
 use std::collections::BTreeMap;
 #[cfg(not(feature = "dhcpv4"))]
-use std::convert::TryInto;
-#[cfg(not(feature = "dhcpv4"))]
 use std::net::Ipv4Addr;
 use std::slice;
 

--- a/hermit-sys/src/net/mod.rs
+++ b/hermit-sys/src/net/mod.rs
@@ -6,7 +6,6 @@ mod waker;
 use aarch64::regs::*;
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::_rdtsc;
-use std::convert::TryInto;
 use std::ops::DerefMut;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicU16, Ordering};

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2021-09-29"
+channel = "nightly-2021-10-20"
 components = [
     "rust-src",
     "llvm-tools-preview",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2021-10-20"
+channel = "nightly-2021-09-29"
 components = [
     "rust-src",
     "llvm-tools-preview",


### PR DESCRIPTION
Replace #172 and fix all clippy warnings

Resolves https://github.com/hermitcore/rusty-hermit/issues/166.