### PR TITLE
Check for kernel manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ rustup component add rust-src
 rustup component add llvm-tools-preview
 ```
 
+If you work with this repository, remember to checkout the submodules.
+
 ## Building your own applications
 
 To give you an example on how to build your application with RustyHermit, lets create a new cargo project:

--- a/hermit-sys/build.rs
+++ b/hermit-sys/build.rs
@@ -11,9 +11,11 @@ use std::process::Command;
 use walkdir::{DirEntry, WalkDir};
 
 fn build_hermit(src_dir: &Path, target_dir_opt: Option<&Path>) {
+	let manifest_path = src_dir.join("Cargo.toml");
 	assert!(
-		src_dir.exists(),
-		"rusty_hermit source folder does not exist"
+		manifest_path.exists(),
+		"kernel manifest path `{}` does not exist",
+		manifest_path.display()
 	);
 	let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
 	let profile = env::var("PROFILE").expect("PROFILE was not set");

--- a/hermit-sys/build.rs
+++ b/hermit-sys/build.rs
@@ -29,7 +29,9 @@ fn build_hermit(src_dir: &Path, target_dir_opt: Option<&Path>) {
 		.arg("-Z")
 		.arg("build-std=core,alloc")
 		.arg("--target")
-		.arg(kernel_triple);
+		.arg(kernel_triple)
+		.arg("--manifest-path")
+		.arg("Cargo.toml");
 
 	cmd.current_dir(src_dir);
 


### PR DESCRIPTION
Closes https://github.com/hermitcore/rusty-hermit/issues/194.

The essence of this PR is adding `--manifest-path Cargo.toml` to the kernel compilation command. Without it, Cargo searches for the Cargo.toml file in the current directory or any parent directory. That results in cargo compiling this repository with the kernel triple, causing https://github.com/hermitcore/rusty-hermit/issues/194.

This does a little refactoring around the kernel triple, adds `--manifest-path Cargo.toml` and adds a manual check for the existence of the kernel manifest. I also added a note to the README for checking out submodules as requested by @tlambertz.