### PR TITLE
removing kernel targets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,4 +77,5 @@ jobs:
         run:
           cargo build -p hello_world --target aarch64-unknown-hermit
       - name: Build aarch64 release profile
+        run:
           cargo build -p hello_world --target aarch64-unknown-hermit --release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,3 +73,8 @@ jobs:
       - name: Build httpd without DHCP support
         run:
           cargo build --package httpd
+      - name: Build aarch64 debug profile
+        run:
+          cargo build -p hello_world --target aarch64-unknown-hermit
+      - name: Build aarch64 release profile
+          cargo build -p hello_world --target aarch64-unknown-hermit --release

--- a/hermit-sys/build.rs
+++ b/hermit-sys/build.rs
@@ -39,8 +39,8 @@ fn build_hermit(src_dir: &Path, target_dir_opt: Option<&Path>) {
 	let mut cmd = Command::new("cargo");
 
 	let kernel_triple = match target_arch.as_str() {
-		"x86_64" => "x86_64-unknown-none-hermitkernel",
-		"aarch64" => "aarch64-unknown-hermit",
+		"x86_64" => "x86_64-unknown-none",
+		"aarch64" => "aarch64-unknown-none-softfloat",
 		_ => panic!("Unsupported target arch: {}", target_arch),
 	};
 


### PR DESCRIPTION
In #197 we discuss to use x86_64-unknown-none target instead of the special `kernel` target. Also the aarch64 port has to useaarch64-unknown-none-softfloat. The floating point unit should not use in the kernel space.