### PR TITLE
try to read static network configuration from environment variables

### DIFF
--- a/hermit-sys/src/net/device.rs
+++ b/hermit-sys/src/net/device.rs
@@ -120,13 +120,20 @@ impl NetworkInterface<HermitNet> {
 				return NetworkState::InitializationFailed;
 			}
 		};
-		let myip: Ipv4Addr = HERMIT_IP.parse().expect("Unable to parse IPv4 address");
+		let myip: Ipv4Addr = std::env::var("HERMIT_IP")
+			.unwrap_or(HERMIT_IP.to_string())
+			.parse()
+			.expect("Unable to parse IPv4 address");
 		let myip = myip.octets();
-		let mygw: Ipv4Addr = HERMIT_GATEWAY
+		let mygw: Ipv4Addr = std::env::var("HERMIT_GATEWAY")
+			.unwrap_or(HERMIT_GATEWAY.to_string())
 			.parse()
 			.expect("Unable to parse IPv4 address");
 		let mygw = mygw.octets();
-		let mymask: Ipv4Addr = HERMIT_MASK.parse().expect("Unable to parse IPv4 address");
+		let mymask: Ipv4Addr = std::env::var("HERMIT_MASK")
+			.unwrap_or(HERMIT_MASK.to_string())
+			.parse()
+			.expect("Unable to parse IPv4 address");
 		let mymask = mymask.octets();
 
 		// calculate the netmask length

--- a/hermit-sys/src/net/device.rs
+++ b/hermit-sys/src/net/device.rs
@@ -121,17 +121,17 @@ impl NetworkInterface<HermitNet> {
 			}
 		};
 		let myip: Ipv4Addr = std::env::var("HERMIT_IP")
-			.unwrap_or(HERMIT_IP.to_string())
+			.unwrap_or_else(|_| HERMIT_IP.to_string())
 			.parse()
 			.expect("Unable to parse IPv4 address");
 		let myip = myip.octets();
 		let mygw: Ipv4Addr = std::env::var("HERMIT_GATEWAY")
-			.unwrap_or(HERMIT_GATEWAY.to_string())
+			.unwrap_or_else(|_| HERMIT_GATEWAY.to_string())
 			.parse()
 			.expect("Unable to parse IPv4 address");
 		let mygw = mygw.octets();
 		let mymask: Ipv4Addr = std::env::var("HERMIT_MASK")
-			.unwrap_or(HERMIT_MASK.to_string())
+			.unwrap_or_else(|_| HERMIT_MASK.to_string())
 			.parse()
 			.expect("Unable to parse IPv4 address");
 		let mymask = mymask.octets();


### PR DESCRIPTION
Currently, when DHCP is not enabled, the network will always be configured according to the constants set at build time for IP address, gateway and subnet mask. This PR allows for reading these values from environment variables. To set these environment variables (for example by taking values from the command line), changes in `libhermit-rs` are necessary. This code will therefore only work with the [corresponding PR](https://github.com/hermitcore/libhermit-rs/pull/337) to `libhermit-rs`.