### PR TITLE
Correctly block on TCP reads

### DIFF
--- a/hermit-sys/src/net/mod.rs
+++ b/hermit-sys/src/net/mod.rs
@@ -259,11 +259,11 @@ impl AsyncSocket {
 				_ => {
 					if s.may_recv() {
 						let n = s.recv_slice(buffer)?;
-						if n > 0 || buffer.len() == 0 {
+						if n > 0 || buffer.is_empty() {
 							return Poll::Ready(Ok(n));
 						}
 					}
-					
+
 					s.register_recv_waker(cx.waker());
 					Poll::Pending
 				}

--- a/hermit-sys/src/net/mod.rs
+++ b/hermit-sys/src/net/mod.rs
@@ -258,11 +258,14 @@ impl AsyncSocket {
 				| TcpState::TimeWait => Poll::Ready(Err(Error::Illegal)),
 				_ => {
 					if s.may_recv() {
-						Poll::Ready(s.recv_slice(buffer))
-					} else {
-						s.register_recv_waker(cx.waker());
-						Poll::Pending
+						let n = s.recv_slice(buffer)?;
+						if n > 0 || buffer.len() == 0 {
+							return Poll::Ready(Ok(n));
+						}
 					}
+					
+					s.register_recv_waker(cx.waker());
+					Poll::Pending
 				}
 			})
 		})


### PR DESCRIPTION
Fixes https://github.com/hermitcore/rusty-hermit/issues/205.

0 should only be returned at EOF or if buffer has length 0.

https://docs.rs/smoltcp/latest/smoltcp/socket/struct.TcpSocket.html#method.recv_slice
https://doc.rust-lang.org/std/io/trait.Read.html#tymethod.read