### PR TITLE
Sys: Fix aarch64 compile error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,6 +354,7 @@ dependencies = [
  "rftrace",
  "smoltcp",
  "tar",
+ "tock-registers",
  "ureq",
  "x86",
 ]

--- a/hermit-sys/Cargo.toml
+++ b/hermit-sys/Cargo.toml
@@ -53,26 +53,30 @@ concurrent-queue = { version = "1.2", optional = true }
 futures-lite = { version = "1.11", optional = true }
 lazy_static = { version = "1.4", optional = true }
 
+rftrace = { version = "0.1", optional = true, features = ["autokernel", "buildcore", "interruptsafe"] }
+
 [dependencies.smoltcp]
 version = "0.7"
 optional = true
 default-features = false
-features = ["std", "ethernet", "socket-udp", "socket-tcp", "proto-ipv4", "proto-ipv6", "async"]
-# to increase the output the features log and verbose should be enabled
-#features = ["log", "verbose", "std", "ethernet", "socket-udp", "socket-tcp", "proto-ipv4", "proto-ipv6", "async"]
+features = [
+    "async",
+    "ethernet",
+    "proto-ipv4",
+    "proto-ipv6",
+    "socket-tcp",
+    "socket-udp",
+    "std",
+    # Enable for increased output
+    # "log",
+    # "verbose",
+]
 
-[dependencies.rftrace]
-version = "0.1"
-optional = true
-features = ["autokernel", "buildcore", "interruptsafe"]
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+x86 = { version = "0.47", default-features = false }
 
-[target.'cfg(target_arch = "x86_64")'.dependencies.x86]
-version = "0.47"
-default-features = false
-
-[target.'cfg(target_arch = "aarch64")'.dependencies.aarch64]
-version = "0.0.7"
-default-features = false
+[target.'cfg(target_arch = "aarch64")'.dependencies]
+aarch64 = { version = "0.0.7", default-features = false }
 
 [build-dependencies]
 flate2 = "1"

--- a/hermit-sys/Cargo.toml
+++ b/hermit-sys/Cargo.toml
@@ -77,6 +77,7 @@ x86 = { version = "0.47", default-features = false }
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 aarch64 = { version = "0.0.7", default-features = false }
+tock-registers = "0.7"
 
 [build-dependencies]
 flate2 = "1"

--- a/hermit-sys/src/net/mod.rs
+++ b/hermit-sys/src/net/mod.rs
@@ -26,6 +26,8 @@ use smoltcp::wire::IpAddress;
 #[cfg(feature = "dhcpv4")]
 use smoltcp::wire::{IpCidr, Ipv4Address, Ipv4Cidr};
 use smoltcp::Error;
+#[cfg(target_arch = "aarch64")]
+use tock_registers::interfaces::Readable;
 
 use crate::net::device::HermitNet;
 use crate::net::executor::{block_on, poll_on, spawn};


### PR DESCRIPTION
Fixes
```
error[E0599]: no method named `get` found for struct `cortex_a::registers::cntpct_el0::Reg` in the current scope
   --> hermit-sys/src/net/mod.rs:351:14
    |
351 |     (CNTPCT_EL0.get() % (u16::MAX as u64)).try_into().unwrap()
    |                 ^^^ method not found in `cortex_a::registers::cntpct_el0::Reg`
    |
   ::: /home/mkroening/.cargo/registry/src/github.com-1ecc6299db9ec823/tock-registers-0.7.0/src/interfaces.rs:168:8
    |
168 |     fn get(&self) -> Self::T;
    |        --- the method is available for `cortex_a::registers::cntpct_el0::Reg` here
    |
    = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
    |
7   | use tock_registers::interfaces::Readable;
    |

For more information about this error, try `rustc --explain E0599`.
error: could not compile `hermit-sys` due to previous error
```