### PR TITLE
Increase version number to publish hermit-abi

### DIFF
--- a/hermit-abi/Cargo.toml
+++ b/hermit-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermit-abi"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Stefan Lankes"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -16,7 +16,7 @@ documentation = "https://hermitcore.github.io/rusty-hermit/hermit_abi"
 
 [dependencies]
 core = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
-alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-core" }
+alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-alloc" }
 compiler_builtins = { version = "0.1", optional = true }
 libc = { version = "0.2", default-features = false }
 

--- a/hermit-abi/src/lib.rs
+++ b/hermit-abi/src/lib.rs
@@ -5,7 +5,6 @@
 #![allow(clippy::missing_safety_doc)]
 #![allow(clippy::result_unit_err)]
 
-#[cfg(feature = "rustc-dep-of-std")]
 pub mod mutex;
 pub mod tcplistener;
 pub mod tcpstream;

--- a/hermit-abi/src/mutex.rs
+++ b/hermit-abi/src/mutex.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "rustc-dep-of-std"))]
+extern crate alloc;
+
 use crate::{
 	block_current_task, get_priority, getpid, wakeup_task, yield_now, Priority, Tid, NO_PRIORITIES,
 };
@@ -29,7 +32,7 @@ unsafe impl<T: ?Sized + Send> Send for Spinlock<T> {}
 /// A guard to which the protected data can be accessed
 ///
 /// When the guard falls out of scope it will release the lock.
-struct SpinlockGuard<'a, T: ?Sized + 'a> {
+struct SpinlockGuard<'a, T: ?Sized> {
 	dequeue: &'a AtomicUsize,
 	data: &'a mut T,
 }
@@ -97,7 +100,7 @@ impl<'a, T: ?Sized> Drop for SpinlockGuard<'a, T> {
 }
 
 /// Realize a priority queue for tasks
-pub struct PriorityQueue {
+struct PriorityQueue {
 	queues: [Option<VecDeque<Tid>>; NO_PRIORITIES],
 	prio_bitmap: u64,
 }


### PR DESCRIPTION
In addition, the Mutex is offered for all users of hermit-abi. The previous version was only available for libstd.