### PR TITLE
Add `block_current_task_with_timeout` syscall

### DIFF
--- a/hermit-abi/src/lib.rs
+++ b/hermit-abi/src/lib.rs
@@ -66,6 +66,7 @@ extern "C" {
 	fn sys_unlink(name: *const i8) -> i32;
 	fn sys_network_init() -> i32;
 	fn sys_block_current_task();
+	fn sys_block_current_task_with_timeout(timeout: u64);
 	fn sys_wakeup_task(tid: Tid);
 	fn sys_get_priority() -> u8;
 	fn sys_set_priority(tid: Tid, prio: u8);
@@ -473,11 +474,20 @@ pub unsafe fn secure_rand64() -> Option<u64> {
 	(res == 0).then(|| rand.assume_init())
 }
 
-/// Add current task to the queue of blocked tasl. After calling `block_current_task`,
+/// Add current task to the queue of blocked tasks. After calling `block_current_task`,
 /// call `yield_now` to switch to another task.
 #[inline(always)]
 pub unsafe fn block_current_task() {
 	sys_block_current_task();
+}
+
+/// Add current task to the queue of blocked tasks, but wake it when `timeout` milliseconds
+/// have elapsed.
+///
+/// After calling `block_current_task`, call `yield_now` to switch to another task.
+#[inline(always)]
+pub unsafe fn block_current_task_with_timeout(timeout: u64) {
+	sys_block_current_task_with_timeout(timeout);
 }
 
 /// Wakeup task with the thread id `tid`


### PR DESCRIPTION
I am currently rewriting the thread parker used in `std` to use the platforms lightweight parking primitives instead of a generic heavy-weight mutex-based implementation. For Hermit, `block_current_task` is the obvious choice. However, `std` also supports setting a timeout for parking, which requires the [`block_current_task_with_timeout`](https://github.com/hermitcore/libhermit-rs/blob/db6a05e0b2eda9d18cf64275475da19f44ddd3a6/src/syscalls/tasks.rs#L307-L311) syscall. 

This PR makes that syscall public. I hope the documentation is correct, I inferred the unit for the timeout from the implementation of `usleep`.