### PR TITLE
use latest version of hermit-abi

### DIFF
--- a/hermit-sys/Cargo.toml
+++ b/hermit-sys/Cargo.toml
@@ -55,7 +55,7 @@ async-task = { version = "4.2", optional = true }
 concurrent-queue = { version = "1.2", optional = true }
 futures-lite = { version = "1.11", optional = true }
 lazy_static = { version = "1.4", optional = true }
-hermit-abi = { version = "0.2.1", optional = true }
+hermit-abi = { version = "0.2.2", optional = true }
 
 rftrace = { version = "0.1", optional = true, features = ["autokernel", "buildcore", "interruptsafe"] }
 


### PR DESCRIPTION
- required to build the network interface