### PR TITLE
increase version number of hermit-sys

### DIFF
--- a/hermit-sys/Cargo.toml
+++ b/hermit-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermit-sys"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Stefan Lankes"]
 license = "MIT/Apache-2.0"
 description = "FFI bindings to HermitCore"

--- a/hermit-sys/build.rs
+++ b/hermit-sys/build.rs
@@ -35,7 +35,7 @@ impl KernelSrc {
 	}
 
 	fn download() -> Self {
-		let version = "0.4.1";
+		let version = "0.4.2";
 		let out_dir = out_dir();
 		let src_dir = out_dir.join(format!("libhermit-rs-{version}"));
 


### PR DESCRIPTION
- based on libhermit-0.4.2, which removes some issues with RTL8139 driver