### PR TITLE
prepare the type `Handle` to generalize IO access

### DIFF
--- a/hermit-abi/src/lib.rs
+++ b/hermit-abi/src/lib.rs
@@ -96,9 +96,22 @@ pub const HIGH_PRIO: Priority = Priority::from(3);
 pub const NORMAL_PRIO: Priority = Priority::from(2);
 pub const LOW_PRIO: Priority = Priority::from(1);
 
-/// A handle, identifying a socket
+/// A handle to identify a socket
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Hash)]
-pub struct Handle(usize);
+pub struct SocketHandle(usize);
+
+/// A handle to identify IO operations
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Handle {
+	Socket(SocketHandle),
+	Invalid,
+}
+
+impl Default for Handle {
+	fn default() -> Self {
+		Handle::Invalid
+	}
+}
 
 pub const NSEC_PER_SEC: u64 = 1_000_000_000;
 pub const CLOCK_REALTIME: u64 = 1;

--- a/hermit-abi/src/tcplistener.rs
+++ b/hermit-abi/src/tcplistener.rs
@@ -1,6 +1,6 @@
 //! `tcplistener` provide an interface to establish tcp socket server.
 
-use crate::{Handle, Handle::Socket, IpAddress, SocketHandle};
+use crate::{Handle, IpAddress, SocketHandle};
 
 extern "Rust" {
 	fn sys_tcp_listener_accept(port: u16) -> Result<(SocketHandle, IpAddress, u16), ()>;

--- a/hermit-abi/src/tcplistener.rs
+++ b/hermit-abi/src/tcplistener.rs
@@ -1,13 +1,14 @@
 //! `tcplistener` provide an interface to establish tcp socket server.
 
-use crate::{Handle, IpAddress};
+use crate::{Handle, Handle::Socket, IpAddress, SocketHandle};
 
 extern "Rust" {
-	fn sys_tcp_listener_accept(port: u16) -> Result<(Handle, IpAddress, u16), ()>;
+	fn sys_tcp_listener_accept(port: u16) -> Result<(SocketHandle, IpAddress, u16), ()>;
 }
 
 /// Wait for connection at specified address.
 #[inline(always)]
 pub fn accept(port: u16) -> Result<(Handle, IpAddress, u16), ()> {
-	unsafe { sys_tcp_listener_accept(port) }
+	let (socket, ip, port) = unsafe { sys_tcp_listener_accept(port)? };
+	Ok((Handle::Socket(socket), ip, port))
 }


### PR DESCRIPTION
Consequently, an enum is used to represent more than a socket descriptor.