### PR TITLE
add try_lock support for spinlock

### DIFF
--- a/hermit-abi/Cargo.toml
+++ b/hermit-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermit-abi"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Stefan Lankes"]
 license = "MIT/Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
Without try_lock support, the mutex isn't able to avoid busy waiting.

Moving some changes of #345 to a new PR to increase the readability.