### PR TITLE
add BSD socket layer

### DIFF
--- a/hermit-abi/Cargo.toml
+++ b/hermit-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermit-abi"
-version = "0.2.6"
+version = "0.3.0"
 authors = ["Stefan Lankes"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/hermit-abi/src/lib.rs
+++ b/hermit-abi/src/lib.rs
@@ -190,9 +190,9 @@ pub struct sockaddr_in6 {
 #[derive(Debug, Copy, Clone)]
 pub struct addrinfo {
 	pub ai_flags: i32,
-    pub ai_family: i32,
-    pub ai_socktype: i32,
-    pub ai_protocol: i32,
+	pub ai_family: i32,
+	pub ai_socktype: i32,
+	pub ai_protocol: i32,
 	pub ai_addrlen: socklen_t,
 	pub ai_addr: *mut sockaddr,
 	pub ai_canonname: *mut u8,
@@ -202,38 +202,38 @@ pub struct addrinfo {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct sockaddr_storage {
-    pub s2_len: u8,
-    pub ss_family: sa_family_t,
-    pub s2_data1: [i8; 2usize],
-    pub s2_data2: [u32; 3usize],
+	pub s2_len: u8,
+	pub ss_family: sa_family_t,
+	pub s2_data1: [i8; 2usize],
+	pub s2_data2: [u32; 3usize],
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ip_mreq {
-    pub imr_multiaddr: in_addr,
-    pub imr_interface: in_addr,
+	pub imr_multiaddr: in_addr,
+	pub imr_interface: in_addr,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ipv6_mreq {
-    pub ipv6mr_multiaddr: in6_addr,
-    pub ipv6mr_interface: u32,
+	pub ipv6mr_multiaddr: in6_addr,
+	pub ipv6mr_interface: u32,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct linger {
-    pub l_onoff: i32,
-    pub l_linger: i32,
+	pub l_onoff: i32,
+	pub l_linger: i32,
 }
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct timeval {
-    pub tv_sec: time_t,
-    pub tv_usec: suseconds_t,
+	pub tv_sec: time_t,
+	pub tv_usec: suseconds_t,
 }
 
 // sysmbols, which are part of the library operating system
@@ -479,15 +479,15 @@ extern "C" {
 	#[link_name = "sys_wakeup_taskt"]
 	pub fn wakeup_task(tid: Tid);
 
-    #[link_name = "sys_accept"]
-    pub fn accept(s: i32, addr: *mut sockaddr, addrlen: *mut socklen_t) -> i32;
+	#[link_name = "sys_accept"]
+	pub fn accept(s: i32, addr: *mut sockaddr, addrlen: *mut socklen_t) -> i32;
 
 	/// bind a name to a socket
-    #[link_name = "sys_bind"]
-    pub fn bind(s: i32, name: *const sockaddr, namelen: socklen_t) -> i32;
+	#[link_name = "sys_bind"]
+	pub fn bind(s: i32, name: *const sockaddr, namelen: socklen_t) -> i32;
 
-    #[link_name = "sys_connect"]
-    pub fn connect(s: i32, name: *const sockaddr, namelen: socklen_t) -> i32;
+	#[link_name = "sys_connect"]
+	pub fn connect(s: i32, name: *const sockaddr, namelen: socklen_t) -> i32;
 
 	/// read from a file descriptor
 	///
@@ -513,105 +513,104 @@ extern "C" {
 	pub fn close(fd: i32) -> i32;
 
 	/// duplicate an existing file descriptor
-    #[link_name = "sys_dup"]
-    pub fn dup(fd: i32) -> i32;
+	#[link_name = "sys_dup"]
+	pub fn dup(fd: i32) -> i32;
 
-    #[link_name = "sys_getpeername"]
-    pub fn getpeername(s: i32, name: *mut sockaddr, namelen: *mut socklen_t) -> i32;
+	#[link_name = "sys_getpeername"]
+	pub fn getpeername(s: i32, name: *mut sockaddr, namelen: *mut socklen_t) -> i32;
 
-    #[link_name = "sys_getsockname"]
-    pub fn getsockname(s: i32, name: *mut sockaddr, namelen: *mut socklen_t) -> i32;
+	#[link_name = "sys_getsockname"]
+	pub fn getsockname(s: i32, name: *mut sockaddr, namelen: *mut socklen_t) -> i32;
 
-    #[link_name = "sys_getsockopt"]
-    pub fn getsockopt(
-        s: i32,
-        level: i32,
-        optname: i32,
-        optval: *mut c_void,
-        optlen: *mut socklen_t,
-    ) -> i32;
+	#[link_name = "sys_getsockopt"]
+	pub fn getsockopt(
+		s: i32,
+		level: i32,
+		optname: i32,
+		optval: *mut c_void,
+		optlen: *mut socklen_t,
+	) -> i32;
 
-    #[link_name = "sys_setsockopt"]
-    pub fn setsockopt(
-        s: i32,
-        level: i32,
-        optname: i32,
-        optval: *const c_void,
-        optlen: socklen_t,
-    ) -> i32;
+	#[link_name = "sys_setsockopt"]
+	pub fn setsockopt(
+		s: i32,
+		level: i32,
+		optname: i32,
+		optval: *const c_void,
+		optlen: socklen_t,
+	) -> i32;
 
-    #[link_name = "sys_ioctl"]
-    pub fn ioctl(s: i32, cmd: i32, argp: *mut c_void) -> i32;
+	#[link_name = "sys_ioctl"]
+	pub fn ioctl(s: i32, cmd: i32, argp: *mut c_void) -> i32;
 
 	/// listen for connections on a socket
-	/// 
+	///
 	/// The `backlog` parameter defines the maximum length for the queue of pending
 	/// connections. Currently, the `backlog` must be one.
-    #[link_name = "sys_listen"]
-    pub fn listen(s: i32, backlog: i32) -> i32;
+	#[link_name = "sys_listen"]
+	pub fn listen(s: i32, backlog: i32) -> i32;
 
-    #[link_name = "sys_recv"]
-    pub fn recv(s: i32, mem: *mut c_void, len: usize, flags: i32) -> isize;
+	#[link_name = "sys_recv"]
+	pub fn recv(s: i32, mem: *mut c_void, len: usize, flags: i32) -> isize;
 
-    /*#[link_name = "SOLID_NET_Readv"]
-    pub fn readv(s: c_int, bufs: *const iovec, bufcnt: c_int) -> ssize_t;
+	/*#[link_name = "SOLID_NET_Readv"]
+	pub fn readv(s: c_int, bufs: *const iovec, bufcnt: c_int) -> ssize_t;
 
-    #[link_name = "SOLID_NET_RecvFrom"]
-    pub fn recvfrom(
-        s: c_int,
-        mem: *mut c_void,
-        len: size_t,
-        flags: c_int,
-        from: *mut sockaddr,
-        fromlen: *mut socklen_t,
-    ) -> ssize_t;*/
+	#[link_name = "SOLID_NET_RecvFrom"]
+	pub fn recvfrom(
+		s: c_int,
+		mem: *mut c_void,
+		len: size_t,
+		flags: c_int,
+		from: *mut sockaddr,
+		fromlen: *mut socklen_t,
+	) -> ssize_t;*/
 
-    #[link_name = "sys_send"]
-    pub fn send(s: i32, mem: *const c_void, len: usize, flags: i32) -> isize;
+	#[link_name = "sys_send"]
+	pub fn send(s: i32, mem: *const c_void, len: usize, flags: i32) -> isize;
 
-    //#[link_name = "SOLID_NET_SendMsg"]
-    //pub fn sendmsg(s: c_int, message: *const msghdr, flags: i32) -> isize;
+	//#[link_name = "SOLID_NET_SendMsg"]
+	//pub fn sendmsg(s: c_int, message: *const msghdr, flags: i32) -> isize;
 
 	#[link_name = "sys_sendto"]
-    pub fn sendto(
-        s: i32,
-        mem: *const c_void,
-        len: usize,
-        flags: i32,
-        to: *const sockaddr,
-        tolen: socklen_t,
-    ) -> isize;
+	pub fn sendto(
+		s: i32,
+		mem: *const c_void,
+		len: usize,
+		flags: i32,
+		to: *const sockaddr,
+		tolen: socklen_t,
+	) -> isize;
 
 	/// shut down part of a full-duplex connection
-    #[link_name = "sys_shutdown_socket"]
-    pub fn shutdown_socket(s: i32, how: i32) -> i32;
+	#[link_name = "sys_shutdown_socket"]
+	pub fn shutdown_socket(s: i32, how: i32) -> i32;
 
-    #[link_name = "sys_socket"]
-    pub fn socket(domain: i32, type_: i32, protocol: i32) -> i32;
+	#[link_name = "sys_socket"]
+	pub fn socket(domain: i32, type_: i32, protocol: i32) -> i32;
 
-    //#[link_name = "SOLID_NET_Writev"]
-    //pub fn writev(s: c_int, bufs: *const iovec, bufcnt: c_int) -> ssize_t;
+	//#[link_name = "SOLID_NET_Writev"]
+	//pub fn writev(s: c_int, bufs: *const iovec, bufcnt: c_int) -> ssize_t;
 
-    #[link_name = "sys_freeaddrinfo"]
-    pub fn freeaddrinfo(ai: *mut addrinfo);
+	#[link_name = "sys_freeaddrinfo"]
+	pub fn freeaddrinfo(ai: *mut addrinfo);
 
-    #[link_name = "sys_getaddrinfo"]
-    pub fn getaddrinfo(
-        nodename: *const i8,
-        servname: *const u8,
-        hints: *const addrinfo,
-        res: *mut *mut addrinfo,
-    ) -> i32;
+	#[link_name = "sys_getaddrinfo"]
+	pub fn getaddrinfo(
+		nodename: *const i8,
+		servname: *const u8,
+		hints: *const addrinfo,
+		res: *mut *mut addrinfo,
+	) -> i32;
 
-    /*#[link_name = "sys_select"]
-    pub fn select(
-        maxfdp1: c_int,
-        readset: *mut fd_set,
-        writeset: *mut fd_set,
-        exceptset: *mut fd_set,
-        timeout: *mut timeval,
-    ) -> i32;*/
-
+	/*#[link_name = "sys_select"]
+	pub fn select(
+		maxfdp1: c_int,
+		readset: *mut fd_set,
+		writeset: *mut fd_set,
+		exceptset: *mut fd_set,
+		timeout: *mut timeval,
+	) -> i32;*/
 
 	fn sys_secure_rand32(value: *mut u32) -> i32;
 	fn sys_secure_rand64(value: *mut u64) -> i32;

--- a/hermit-abi/src/lib.rs
+++ b/hermit-abi/src/lib.rs
@@ -2,6 +2,7 @@
 //! [RustyHermit](https://github.com/hermitcore/libhermit-rs).
 
 #![no_std]
+#![allow(nonstandard_style)]
 #![allow(clippy::missing_safety_doc)]
 #![allow(clippy::result_unit_err)]
 
@@ -12,72 +13,6 @@ pub mod tcpstream;
 use core::mem::MaybeUninit;
 
 use core::ffi::{c_int, c_void};
-
-// sysmbols, which are part of the library operating system
-
-extern "C" {
-	fn sys_rand() -> u32;
-	fn sys_srand(seed: u32);
-	fn sys_secure_rand32(value: *mut u32) -> i32;
-	fn sys_secure_rand64(value: *mut u64) -> i32;
-	fn sys_get_processor_count() -> usize;
-	fn sys_malloc(size: usize, align: usize) -> *mut u8;
-	fn sys_realloc(ptr: *mut u8, size: usize, align: usize, new_size: usize) -> *mut u8;
-	fn sys_free(ptr: *mut u8, size: usize, align: usize);
-	fn sys_init_queue(ptr: usize) -> i32;
-	fn sys_notify(id: usize, count: i32) -> i32;
-	fn sys_add_queue(id: usize, timeout_ns: i64) -> i32;
-	fn sys_wait(id: usize) -> i32;
-	fn sys_destroy_queue(id: usize) -> i32;
-	fn sys_read(fd: i32, buf: *mut u8, len: usize) -> isize;
-	fn sys_write(fd: i32, buf: *const u8, len: usize) -> isize;
-	fn sys_close(fd: i32) -> i32;
-	fn sys_futex_wait(
-		address: *mut u32,
-		expected: u32,
-		timeout: *const timespec,
-		flags: u32,
-	) -> i32;
-	fn sys_futex_wake(address: *mut u32, count: i32) -> i32;
-	fn sys_sem_init(sem: *mut *const c_void, value: u32) -> i32;
-	fn sys_sem_destroy(sem: *const c_void) -> i32;
-	fn sys_sem_post(sem: *const c_void) -> i32;
-	fn sys_sem_trywait(sem: *const c_void) -> i32;
-	fn sys_sem_timedwait(sem: *const c_void, ms: u32) -> i32;
-	fn sys_recmutex_init(recmutex: *mut *const c_void) -> i32;
-	fn sys_recmutex_destroy(recmutex: *const c_void) -> i32;
-	fn sys_recmutex_lock(recmutex: *const c_void) -> i32;
-	fn sys_recmutex_unlock(recmutex: *const c_void) -> i32;
-	fn sys_getpid() -> u32;
-	fn sys_exit(arg: i32) -> !;
-	fn sys_abort() -> !;
-	fn sys_usleep(usecs: u64);
-	fn sys_spawn(
-		id: *mut Tid,
-		func: extern "C" fn(usize),
-		arg: usize,
-		prio: u8,
-		core_id: isize,
-	) -> i32;
-	fn sys_spawn2(
-		func: extern "C" fn(usize),
-		arg: usize,
-		prio: u8,
-		stack_size: usize,
-		core_id: isize,
-	) -> Tid;
-	fn sys_join(id: Tid) -> i32;
-	fn sys_yield();
-	fn sys_clock_gettime(clock_id: u64, tp: *mut timespec) -> i32;
-	fn sys_open(name: *const i8, flags: i32, mode: i32) -> i32;
-	fn sys_unlink(name: *const i8) -> i32;
-	fn sys_network_init() -> i32;
-	fn sys_block_current_task();
-	fn sys_block_current_task_with_timeout(timeout: u64);
-	fn sys_wakeup_task(tid: Tid);
-	fn sys_get_priority() -> u8;
-	fn sys_set_priority(tid: Tid, prio: u8);
-}
 
 /// A thread handle type
 pub type Tid = u32;
@@ -127,11 +62,6 @@ pub fn isatty(_fd: c_int) -> bool {
 	false
 }
 
-/// initialize the network stack
-pub fn network_init() -> i32 {
-	unsafe { sys_network_init() }
-}
-
 /// `timespec` is used by `clock_gettime` to retrieve the
 /// current time
 #[derive(Copy, Clone, Debug)]
@@ -171,322 +101,522 @@ pub enum IpAddress {
 	Ipv6(Ipv6Address),
 }
 
-/// determines the number of activated processors
-#[inline(always)]
-pub unsafe fn get_processor_count() -> usize {
-	sys_get_processor_count()
-}
-
-#[doc(hidden)]
-#[inline(always)]
-pub unsafe fn malloc(size: usize, align: usize) -> *mut u8 {
-	sys_malloc(size, align)
-}
-
-#[doc(hidden)]
-#[inline(always)]
-pub unsafe fn realloc(ptr: *mut u8, size: usize, align: usize, new_size: usize) -> *mut u8 {
-	sys_realloc(ptr, size, align, new_size)
-}
-
-#[doc(hidden)]
-#[inline(always)]
-pub unsafe fn free(ptr: *mut u8, size: usize, align: usize) {
-	sys_free(ptr, size, align)
-}
-
-#[inline(always)]
-pub unsafe fn notify(id: usize, count: i32) -> i32 {
-	sys_notify(id, count)
-}
-
-#[doc(hidden)]
-#[inline(always)]
-pub unsafe fn add_queue(id: usize, timeout_ns: i64) -> i32 {
-	sys_add_queue(id, timeout_ns)
-}
-
-#[doc(hidden)]
-#[inline(always)]
-pub unsafe fn wait(id: usize) -> i32 {
-	sys_wait(id)
-}
-
-#[doc(hidden)]
-#[inline(always)]
-pub unsafe fn init_queue(id: usize) -> i32 {
-	sys_init_queue(id)
-}
-
-#[doc(hidden)]
-#[inline(always)]
-pub unsafe fn destroy_queue(id: usize) -> i32 {
-	sys_destroy_queue(id)
-}
-
-/// read from a file descriptor
-///
-/// read() attempts to read `len` bytes of data from the object
-/// referenced by the descriptor `fd` into the buffer pointed
-/// to by `buf`.
-#[inline(always)]
-pub unsafe fn read(fd: i32, buf: *mut u8, len: usize) -> isize {
-	sys_read(fd, buf, len)
-}
-
-/// write to a file descriptor
-///
-/// write() attempts to write `len` of data to the object
-/// referenced by the descriptor `fd` from the
-/// buffer pointed to by `buf`.
-#[inline(always)]
-pub unsafe fn write(fd: i32, buf: *const u8, len: usize) -> isize {
-	sys_write(fd, buf, len)
-}
-
-/// close a file descriptor
-///
-/// The close() call deletes a file descriptor `fd` from the object
-/// reference table.
-#[inline(always)]
-pub unsafe fn close(fd: i32) -> i32 {
-	sys_close(fd)
-}
-
-/// If the value at address matches the expected value, park the current thread until it is either
-/// woken up with [`futex_wake`] (returns 0) or an optional timeout elapses (returns -ETIMEDOUT).
-///
-/// Setting `timeout` to null means the function will only return if [`futex_wake`] is called.
-/// Otherwise, `timeout` is interpreted as an absolute time measured with [`CLOCK_MONOTONIC`].
-/// If [`FUTEX_RELATIVE_TIMEOUT`] is set in `flags` the timeout is understood to be relative
-/// to the current time.
-///
-/// Returns -EINVAL if `address` is null, the timeout is negative or `flags` contains unknown values.
-#[inline(always)]
-pub unsafe fn futex_wait(
-	address: *mut u32,
-	expected: u32,
-	timeout: *const timespec,
-	flags: u32,
-) -> i32 {
-	sys_futex_wait(address, expected, timeout, flags)
-}
-
-/// Wake `count` threads waiting on the futex at `address`. Returns the number of threads
-/// woken up (saturates to `i32::MAX`). If `count` is `i32::MAX`, wake up all matching
-/// waiting threads. If `count` is negative or `address` is null, returns -EINVAL.
-#[inline(always)]
-pub unsafe fn futex_wake(address: *mut u32, count: i32) -> i32 {
-	sys_futex_wake(address, count)
-}
-
-/// sem_init() initializes the unnamed semaphore at the address
-/// pointed to by `sem`.  The `value` argument specifies the
-/// initial value for the semaphore.
-#[inline(always)]
-pub unsafe fn sem_init(sem: *mut *const c_void, value: u32) -> i32 {
-	sys_sem_init(sem, value)
-}
-
-/// sem_destroy() frees the unnamed semaphore at the address
-/// pointed to by `sem`.
-#[inline(always)]
-pub unsafe fn sem_destroy(sem: *const c_void) -> i32 {
-	sys_sem_destroy(sem)
-}
-
-/// sem_post() increments the semaphore pointed to by `sem`.
-/// If the semaphore's value consequently becomes greater
-/// than zero, then another thread blocked in a sem_wait call
-/// will be woken up and proceed to lock the semaphore.
-#[inline(always)]
-pub unsafe fn sem_post(sem: *const c_void) -> i32 {
-	sys_sem_post(sem)
-}
-
-/// try to decrement a semaphore
-///
-/// sem_trywait() is the same as sem_timedwait(), except that
-/// if the  decrement cannot be immediately performed, then  call
-/// returns a negative value instead of blocking.
-#[inline(always)]
-pub unsafe fn sem_trywait(sem: *const c_void) -> i32 {
-	sys_sem_trywait(sem)
-}
-
-/// decrement a semaphore
-///
-/// sem_timedwait() decrements the semaphore pointed to by `sem`.
-/// If the semaphore's value is greater than zero, then the
-/// the function returns immediately. If the semaphore currently
-/// has the value zero, then the call blocks until either
-/// it becomes possible to perform the decrement of the time limit
-/// to wait for the semaphore is expired. A time limit `ms` of
-/// means infinity waiting time.
-#[inline(always)]
-pub unsafe fn sem_timedwait(sem: *const c_void, ms: u32) -> i32 {
-	sys_sem_timedwait(sem, ms)
-}
-
-#[doc(hidden)]
-#[inline(always)]
-pub unsafe fn recmutex_init(recmutex: *mut *const c_void) -> i32 {
-	sys_recmutex_init(recmutex)
-}
-
-#[doc(hidden)]
-#[inline(always)]
-pub unsafe fn recmutex_destroy(recmutex: *const c_void) -> i32 {
-	sys_recmutex_destroy(recmutex)
-}
-
-#[doc(hidden)]
-#[inline(always)]
-pub unsafe fn recmutex_lock(recmutex: *const c_void) -> i32 {
-	sys_recmutex_lock(recmutex)
-}
-
-#[doc(hidden)]
-#[inline(always)]
-pub unsafe fn recmutex_unlock(recmutex: *const c_void) -> i32 {
-	sys_recmutex_unlock(recmutex)
-}
-
-/// Determines the id of the current thread
-#[inline(always)]
-pub unsafe fn getpid() -> u32 {
-	sys_getpid()
-}
-
-/// cause normal termination and return `arg`
-/// to the host system
-#[inline(always)]
-pub unsafe fn exit(arg: i32) -> ! {
-	sys_exit(arg)
-}
-
-/// cause abnormal termination
-#[inline(always)]
-pub unsafe fn abort() -> ! {
-	sys_abort()
-}
-
-/// suspend execution for microsecond intervals
-///
-/// The usleep() function suspends execution of the calling
-/// thread for (at least) `usecs` microseconds.
-#[inline(always)]
-pub unsafe fn usleep(usecs: u64) {
-	sys_usleep(usecs)
-}
-
-/// spawn a new thread
-///
-/// spawn() starts a new thread. The new thread starts execution
-/// by invoking `func(usize)`; `arg` is passed as the argument
-/// to `func`. `prio` defines the priority of the new thread,
-/// which can be between `LOW_PRIO` and `HIGH_PRIO`.
-/// `core_id` defines the core, where the thread is located.
-/// A negative value give the operating system the possibility
-/// to select the core by its own.
-#[inline(always)]
-pub unsafe fn spawn(
-	id: *mut Tid,
-	func: extern "C" fn(usize),
-	arg: usize,
-	prio: u8,
-	core_id: isize,
-) -> i32 {
-	sys_spawn(id, func, arg, prio, core_id)
-}
-
-/// spawn a new thread with user-specified stack size
-///
-/// spawn2() starts a new thread. The new thread starts execution
-/// by invoking `func(usize)`; `arg` is passed as the argument
-/// to `func`. `prio` defines the priority of the new thread,
-/// which can be between `LOW_PRIO` and `HIGH_PRIO`.
-/// `core_id` defines the core, where the thread is located.
-/// A negative value give the operating system the possibility
-/// to select the core by its own.
-/// In contrast to spawn(), spawn2() is able to define the
-/// stack size.
-#[inline(always)]
-pub unsafe fn spawn2(
-	func: extern "C" fn(usize),
-	arg: usize,
-	prio: u8,
-	stack_size: usize,
-	core_id: isize,
-) -> Tid {
-	sys_spawn2(func, arg, prio, stack_size, core_id)
-}
-
-/// join with a terminated thread
-///
-/// The join() function waits for the thread specified by `id`
-/// to terminate.
-#[inline(always)]
-pub unsafe fn join(id: Tid) -> i32 {
-	sys_join(id)
-}
-
-/// yield the processor
-///
-/// causes the calling thread to relinquish the CPU. The thread
-/// is moved to the end of the queue for its static priority.
-#[inline(always)]
-pub unsafe fn yield_now() {
-	sys_yield()
-}
-
-/// get current time
-///
-/// The clock_gettime() functions allow the calling thread
-/// to retrieve the value used by a clock which is specified
-/// by `clock_id`.
-///
-/// `CLOCK_REALTIME`: the system's real time clock,
-/// expressed as the amount of time since the Epoch.
-///
-/// `CLOCK_MONOTONIC`: clock that increments monotonically,
-/// tracking the time since an arbitrary point
-#[inline(always)]
-pub unsafe fn clock_gettime(clock_id: u64, tp: *mut timespec) -> i32 {
-	sys_clock_gettime(clock_id, tp)
-}
-
-/// open and possibly create a file
-///
-/// The open() system call opens the file specified by `name`.
-/// If the specified file does not exist, it may optionally
-/// be created by open().
-#[inline(always)]
-pub unsafe fn open(name: *const i8, flags: i32, mode: i32) -> i32 {
-	sys_open(name, flags, mode)
-}
-
-/// delete the file it refers to `name`
-#[inline(always)]
-pub unsafe fn unlink(name: *const i8) -> i32 {
-	sys_unlink(name)
-}
-
 /// The largest number `rand` will return
 pub const RAND_MAX: u64 = 2_147_483_647;
 
-/// The function computes a sequence of pseudo-random integers
-/// in the range of 0 to RAND_MAX
-#[inline(always)]
-pub unsafe fn rand() -> u32 {
-	sys_rand()
+pub const AF_INET: i32 = 0;
+pub const AF_INET6: i32 = 1;
+pub const IPPROTO_IP: i32 = 0;
+pub const IPPROTO_IPV6: i32 = 41;
+pub const IPPROTO_UDP: i32 = 17;
+pub const IPPROTO_TCP: i32 = 6;
+pub const IPV6_ADD_MEMBERSHIP: i32 = 12;
+pub const IPV6_DROP_MEMBERSHIP: i32 = 13;
+pub const IPV6_MULTICAST_LOOP: i32 = 19;
+pub const IPV6_V6ONLY: i32 = 27;
+pub const IP_TTL: i32 = 2;
+pub const IP_MULTICAST_TTL: i32 = 5;
+pub const IP_MULTICAST_LOOP: i32 = 7;
+pub const IP_ADD_MEMBERSHIP: i32 = 3;
+pub const IP_DROP_MEMBERSHIP: i32 = 4;
+pub const SHUT_RD: i32 = 0;
+pub const SHUT_WR: i32 = 1;
+pub const SHUT_RDWR: i32 = 2;
+pub const SOCK_DGRAM: i32 = 2;
+pub const SOCK_STREAM: i32 = 1;
+pub const SOL_SOCKET: i32 = 4095;
+pub const SO_BROADCAST: i32 = 32;
+pub const SO_ERROR: i32 = 4103;
+pub const SO_RCVTIMEO: i32 = 4102;
+pub const SO_REUSEADDR: i32 = 4;
+pub const SO_SNDTIMEO: i32 = 4101;
+pub const SO_LINGER: i32 = 128;
+pub const TCP_NODELAY: i32 = 1;
+pub const MSG_PEEK: i32 = 1;
+pub const FIONBIO: i32 = 0x8008667eu32 as i32;
+pub const EAI_NONAME: i32 = -2200;
+pub const EAI_SERVICE: i32 = -2201;
+pub const EAI_FAIL: i32 = -2202;
+pub const EAI_MEMORY: i32 = -2203;
+pub const EAI_FAMILY: i32 = -2204;
+pub type sa_family_t = u8;
+pub type socklen_t = u32;
+pub type in_addr_t = u32;
+pub type in_port_t = u16;
+pub type time_t = i64;
+pub type suseconds_t = i64;
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct in_addr {
+	pub s_addr: u32,
 }
 
-/// The function sets its argument as the seed for a new sequence
-/// of pseudo-random numbers to be returned by `rand`
-#[inline(always)]
-pub unsafe fn srand(seed: u32) {
-	sys_srand(seed);
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct in6_addr {
+	pub s6_addr: [u8; 16],
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sockaddr {
+	pub sa_len: u8,
+	pub sa_family: sa_family_t,
+	pub sa_data: [u8; 14],
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sockaddr_in {
+	pub sin_len: u8,
+	pub sin_family: sa_family_t,
+	pub sin_port: u16,
+	pub sin_addr: in_addr,
+	pub sin_zero: [u8; 8],
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sockaddr_in6 {
+	pub sin6_family: sa_family_t,
+	pub sin6_port: u16,
+	pub sin6_addr: in6_addr,
+	pub sin6_flowinfo: u32,
+	pub sin6_scope_id: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct addrinfo {
+	pub ai_flags: i32,
+    pub ai_family: i32,
+    pub ai_socktype: i32,
+    pub ai_protocol: i32,
+	pub ai_addrlen: socklen_t,
+	pub ai_addr: *mut sockaddr,
+	pub ai_canonname: *mut u8,
+	pub ai_next: *mut addrinfo,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct sockaddr_storage {
+    pub s2_len: u8,
+    pub ss_family: sa_family_t,
+    pub s2_data1: [i8; 2usize],
+    pub s2_data2: [u32; 3usize],
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ip_mreq {
+    pub imr_multiaddr: in_addr,
+    pub imr_interface: in_addr,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ipv6_mreq {
+    pub ipv6mr_multiaddr: in6_addr,
+    pub ipv6mr_interface: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct linger {
+    pub l_onoff: i32,
+    pub l_linger: i32,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timeval {
+    pub tv_sec: time_t,
+    pub tv_usec: suseconds_t,
+}
+
+// sysmbols, which are part of the library operating system
+extern "C" {
+	/// If the value at address matches the expected value, park the current thread until it is either
+	/// woken up with [`futex_wake`] (returns 0) or an optional timeout elapses (returns -ETIMEDOUT).
+	///
+	/// Setting `timeout` to null means the function will only return if [`futex_wake`] is called.
+	/// Otherwise, `timeout` is interpreted as an absolute time measured with [`CLOCK_MONOTONIC`].
+	/// If [`FUTEX_RELATIVE_TIMEOUT`] is set in `flags` the timeout is understood to be relative
+	/// to the current time.
+	///
+	/// Returns -EINVAL if `address` is null, the timeout is negative or `flags` contains unknown values.
+	#[link_name = "sys_futex_wait"]
+	pub fn futex_wait(
+		address: *mut u32,
+		expected: u32,
+		timeout: *const timespec,
+		flags: u32,
+	) -> i32;
+
+	/// Wake `count` threads waiting on the futex at `address`. Returns the number of threads
+	/// woken up (saturates to `i32::MAX`). If `count` is `i32::MAX`, wake up all matching
+	/// waiting threads. If `count` is negative or `address` is null, returns -EINVAL.
+	#[link_name = "sys_futex_wake"]
+	pub fn futex_wake(address: *mut u32, count: i32) -> i32;
+
+	/// sem_init() initializes the unnamed semaphore at the address
+	/// pointed to by `sem`.  The `value` argument specifies the
+	/// initial value for the semaphore.
+	#[link_name = "sys_sem_init"]
+	pub fn sem_init(sem: *mut *const c_void, value: u32) -> i32;
+
+	/// sem_destroy() frees the unnamed semaphore at the address
+	/// pointed to by `sem`.
+	#[link_name = "sys_sem_destroy"]
+	pub fn sem_destroy(sem: *const c_void) -> i32;
+
+	/// sem_post() increments the semaphore pointed to by `sem`.
+	/// If the semaphore's value consequently becomes greater
+	/// than zero, then another thread blocked in a sem_wait call
+	/// will be woken up and proceed to lock the semaphore.
+	#[link_name = "sys_sem_post"]
+	pub fn sem_post(sem: *const c_void) -> i32;
+
+	/// try to decrement a semaphore
+	///
+	/// sem_trywait() is the same as sem_timedwait(), except that
+	/// if the  decrement cannot be immediately performed, then  call
+	/// returns a negative value instead of blocking.
+	#[link_name = "sys_sem_trywait"]
+	pub fn sem_trywait(sem: *const c_void) -> i32;
+
+	/// decrement a semaphore
+	///
+	/// sem_timedwait() decrements the semaphore pointed to by `sem`.
+	/// If the semaphore's value is greater than zero, then the
+	/// the function returns immediately. If the semaphore currently
+	/// has the value zero, then the call blocks until either
+	/// it becomes possible to perform the decrement of the time limit
+	/// to wait for the semaphore is expired. A time limit `ms` of
+	/// means infinity waiting time.
+	#[link_name = "sys_timedwait"]
+	pub fn sem_timedwait(sem: *const c_void, ms: u32) -> i32;
+
+	/*
+	#[doc(hidden)]
+	#[link_name = "sys_recmutex_init"]
+	pub fn recmutex_init(recmutex: *mut *const c_void) -> i32;
+
+	#[doc(hidden)]
+	#[link_name = "sys_recmutex_destroy"]
+	pub fn recmutex_destroy(recmutex: *const c_void) -> i32;
+
+	#[doc(hidden)]
+	#[link_name = "sys_recmutex_lock"]
+	pub fn recmutex_lock(recmutex: *const c_void) -> i32;
+
+	#[doc(hidden)]
+	#[link_name = "sys_recmutex_unlock"]
+	pub fn recmutex_unlock(recmutex: *const c_void) -> i32;
+	*/
+
+	/// Determines the id of the current thread
+	#[link_name = "sys_getpid"]
+	pub fn getpid() -> u32;
+
+	/// cause normal termination and return `arg`
+	/// to the host system
+	#[link_name = "sys_exit"]
+	pub fn exit(arg: i32) -> !;
+
+	/// cause abnormal termination
+	#[link_name = "sys_abort"]
+	pub fn abort() -> !;
+
+	/// suspend execution for microsecond intervals
+	///
+	/// The usleep() function suspends execution of the calling
+	/// thread for (at least) `usecs` microseconds.
+	#[link_name = "sys_usleep"]
+	pub fn usleep(usecs: u64);
+
+	/// spawn a new thread
+	///
+	/// spawn() starts a new thread. The new thread starts execution
+	/// by invoking `func(usize)`; `arg` is passed as the argument
+	/// to `func`. `prio` defines the priority of the new thread,
+	/// which can be between `LOW_PRIO` and `HIGH_PRIO`.
+	/// `core_id` defines the core, where the thread is located.
+	/// A negative value give the operating system the possibility
+	/// to select the core by its own.
+	#[link_name = "sys_spawn"]
+	pub fn spawn(
+		id: *mut Tid,
+		func: extern "C" fn(usize),
+		arg: usize,
+		prio: u8,
+		core_id: isize,
+	) -> i32;
+
+	/// spawn a new thread with user-specified stack size
+	///
+	/// spawn2() starts a new thread. The new thread starts execution
+	/// by invoking `func(usize)`; `arg` is passed as the argument
+	/// to `func`. `prio` defines the priority of the new thread,
+	/// which can be between `LOW_PRIO` and `HIGH_PRIO`.
+	/// `core_id` defines the core, where the thread is located.
+	/// A negative value give the operating system the possibility
+	/// to select the core by its own.
+	/// In contrast to spawn(), spawn2() is able to define the
+	/// stack size.
+	#[link_name = "sys_spawn2"]
+	pub fn spawn2(
+		func: extern "C" fn(usize),
+		arg: usize,
+		prio: u8,
+		stack_size: usize,
+		core_id: isize,
+	) -> Tid;
+
+	/// join with a terminated thread
+	///
+	/// The join() function waits for the thread specified by `id`
+	/// to terminate.
+	#[link_name = "sys_join"]
+	pub fn join(id: Tid) -> i32;
+
+	/// yield the processor
+	///
+	/// causes the calling thread to relinquish the CPU. The thread
+	/// is moved to the end of the queue for its static priority.
+	#[link_name = "sys_yield"]
+	pub fn yield_now();
+
+	/// get current time
+	///
+	/// The clock_gettime() functions allow the calling thread
+	/// to retrieve the value used by a clock which is specified
+	/// by `clock_id`.
+	///
+	/// `CLOCK_REALTIME`: the system's real time clock,
+	/// expressed as the amount of time since the Epoch.
+	///
+	/// `CLOCK_MONOTONIC`: clock that increments monotonically,
+	/// tracking the time since an arbitrary point
+	#[link_name = "sys_clock_gettime"]
+	pub fn clock_gettime(clock_id: u64, tp: *mut timespec) -> i32;
+
+	/// open and possibly create a file
+	///
+	/// The open() system call opens the file specified by `name`.
+	/// If the specified file does not exist, it may optionally
+	/// be created by open().
+	#[link_name = "sys_open"]
+	pub fn open(name: *const i8, flags: i32, mode: i32) -> i32;
+
+	/// delete the file it refers to `name`
+	#[link_name = "sys_unlink"]
+	pub fn unlink(name: *const i8) -> i32;
+
+	/// determines the number of activated processors
+	#[link_name = "sys_processor_count"]
+	pub fn get_processor_count() -> usize;
+
+	#[link_name = "sys_malloc"]
+	pub fn malloc(size: usize, align: usize) -> *mut u8;
+
+	#[doc(hidden)]
+	#[link_name = "sys_realloc"]
+	pub fn realloc(ptr: *mut u8, size: usize, align: usize, new_size: usize) -> *mut u8;
+
+	#[doc(hidden)]
+	#[link_name = "sys_free"]
+	pub fn free(ptr: *mut u8, size: usize, align: usize);
+
+	#[link_name = "sys_notify"]
+	pub fn notify(id: usize, count: i32) -> i32;
+
+	#[doc(hidden)]
+	#[link_name = "sys_add_queue"]
+	pub fn add_queue(id: usize, timeout_ns: i64) -> i32;
+
+	#[doc(hidden)]
+	#[link_name = "sys_wait"]
+	pub fn wait(id: usize) -> i32;
+
+	#[doc(hidden)]
+	#[link_name = "sys_init_queue"]
+	pub fn init_queue(id: usize) -> i32;
+
+	#[doc(hidden)]
+	#[link_name = "sys_destroy_queue"]
+	pub fn destroy_queue(id: usize) -> i32;
+
+	/// initialize the network stack
+	#[link_name = "sys_network_init"]
+	pub fn network_init() -> i32;
+
+	/// The function computes a sequence of pseudo-random integers
+	/// in the range of 0 to RAND_MAX
+	#[link_name = "sys_rand"]
+	pub fn rand() -> u32;
+
+	/// The function sets its argument as the seed for a new sequence
+	/// of pseudo-random numbers to be returned by `rand`
+	#[link_name = "sys_srand"]
+	pub fn srand(seed: u32);
+
+	/// Add current task to the queue of blocked tasks. After calling `block_current_task`,
+	/// call `yield_now` to switch to another task.
+	#[link_name = "sys_block_current_task"]
+	pub fn block_current_task();
+
+	/// Add current task to the queue of blocked tasks, but wake it when `timeout` milliseconds
+	/// have elapsed.
+	///
+	/// After calling `block_current_task`, call `yield_now` to switch to another task.
+	#[link_name = "sys_block_current_task_with_timeout"]
+	pub fn block_current_task_with_timeout(timeout: u64);
+
+	/// Wakeup task with the thread id `tid`
+	#[link_name = "sys_wakeup_taskt"]
+	pub fn wakeup_task(tid: Tid);
+
+    #[link_name = "sys_accept"]
+    pub fn accept(s: i32, addr: *mut sockaddr, addrlen: *mut socklen_t) -> i32;
+
+	/// bind a name to a socket
+    #[link_name = "sys_bind"]
+    pub fn bind(s: i32, name: *const sockaddr, namelen: socklen_t) -> i32;
+
+    #[link_name = "sys_connect"]
+    pub fn connect(s: i32, name: *const sockaddr, namelen: socklen_t) -> i32;
+
+	/// read from a file descriptor
+	///
+	/// read() attempts to read `len` bytes of data from the object
+	/// referenced by the descriptor `fd` into the buffer pointed
+	/// to by `buf`.
+	#[link_name = "sys_read"]
+	pub fn read(fd: i32, buf: *mut u8, len: usize) -> isize;
+
+	/// write to a file descriptor
+	///
+	/// write() attempts to write `len` of data to the object
+	/// referenced by the descriptor `fd` from the
+	/// buffer pointed to by `buf`.
+	#[link_name = "sys_write"]
+	pub fn write(fd: i32, buf: *const u8, len: usize) -> isize;
+
+	/// close a file descriptor
+	///
+	/// The close() call deletes a file descriptor `fd` from the object
+	/// reference table.
+	#[link_name = "sys_close"]
+	pub fn close(fd: i32) -> i32;
+
+	/// duplicate an existing file descriptor
+    #[link_name = "sys_dup"]
+    pub fn dup(fd: i32) -> i32;
+
+    #[link_name = "sys_getpeername"]
+    pub fn getpeername(s: i32, name: *mut sockaddr, namelen: *mut socklen_t) -> i32;
+
+    #[link_name = "sys_getsockname"]
+    pub fn getsockname(s: i32, name: *mut sockaddr, namelen: *mut socklen_t) -> i32;
+
+    #[link_name = "sys_getsockopt"]
+    pub fn getsockopt(
+        s: i32,
+        level: i32,
+        optname: i32,
+        optval: *mut c_void,
+        optlen: *mut socklen_t,
+    ) -> i32;
+
+    #[link_name = "sys_setsockopt"]
+    pub fn setsockopt(
+        s: i32,
+        level: i32,
+        optname: i32,
+        optval: *const c_void,
+        optlen: socklen_t,
+    ) -> i32;
+
+    #[link_name = "sys_ioctl"]
+    pub fn ioctl(s: i32, cmd: i32, argp: *mut c_void) -> i32;
+
+	/// listen for connections on a socket
+	/// 
+	/// The `backlog` parameter defines the maximum length for the queue of pending
+	/// connections. Currently, the `backlog` must be one.
+    #[link_name = "sys_listen"]
+    pub fn listen(s: i32, backlog: i32) -> i32;
+
+    #[link_name = "sys_recv"]
+    pub fn recv(s: i32, mem: *mut c_void, len: usize, flags: i32) -> isize;
+
+    /*#[link_name = "SOLID_NET_Readv"]
+    pub fn readv(s: c_int, bufs: *const iovec, bufcnt: c_int) -> ssize_t;
+
+    #[link_name = "SOLID_NET_RecvFrom"]
+    pub fn recvfrom(
+        s: c_int,
+        mem: *mut c_void,
+        len: size_t,
+        flags: c_int,
+        from: *mut sockaddr,
+        fromlen: *mut socklen_t,
+    ) -> ssize_t;*/
+
+    #[link_name = "sys_send"]
+    pub fn send(s: i32, mem: *const c_void, len: usize, flags: i32) -> isize;
+
+    //#[link_name = "SOLID_NET_SendMsg"]
+    //pub fn sendmsg(s: c_int, message: *const msghdr, flags: i32) -> isize;
+
+	#[link_name = "sys_sendto"]
+    pub fn sendto(
+        s: i32,
+        mem: *const c_void,
+        len: usize,
+        flags: i32,
+        to: *const sockaddr,
+        tolen: socklen_t,
+    ) -> isize;
+
+	/// shut down part of a full-duplex connection
+    #[link_name = "sys_shutdown_socket"]
+    pub fn shutdown_socket(s: i32, how: i32) -> i32;
+
+    #[link_name = "sys_socket"]
+    pub fn socket(domain: i32, type_: i32, protocol: i32) -> i32;
+
+    //#[link_name = "SOLID_NET_Writev"]
+    //pub fn writev(s: c_int, bufs: *const iovec, bufcnt: c_int) -> ssize_t;
+
+    #[link_name = "sys_freeaddrinfo"]
+    pub fn freeaddrinfo(ai: *mut addrinfo);
+
+    #[link_name = "sys_getaddrinfo"]
+    pub fn getaddrinfo(
+        nodename: *const i8,
+        servname: *const u8,
+        hints: *const addrinfo,
+        res: *mut *mut addrinfo,
+    ) -> i32;
+
+    /*#[link_name = "sys_select"]
+    pub fn select(
+        maxfdp1: c_int,
+        readset: *mut fd_set,
+        writeset: *mut fd_set,
+        exceptset: *mut fd_set,
+        timeout: *mut timeval,
+    ) -> i32;*/
+
+
+	fn sys_secure_rand32(value: *mut u32) -> i32;
+	fn sys_secure_rand64(value: *mut u64) -> i32;
+	fn sys_get_priority() -> u8;
+	fn sys_set_priority(tid: Tid, prio: u8);
 }
 
 /// Create a cryptographicly secure 32bit random number with the support of
@@ -507,28 +637,6 @@ pub unsafe fn secure_rand64() -> Option<u64> {
 	let mut rand = MaybeUninit::uninit();
 	let res = sys_secure_rand64(rand.as_mut_ptr());
 	(res == 0).then(|| rand.assume_init())
-}
-
-/// Add current task to the queue of blocked tasks. After calling `block_current_task`,
-/// call `yield_now` to switch to another task.
-#[inline(always)]
-pub unsafe fn block_current_task() {
-	sys_block_current_task();
-}
-
-/// Add current task to the queue of blocked tasks, but wake it when `timeout` milliseconds
-/// have elapsed.
-///
-/// After calling `block_current_task`, call `yield_now` to switch to another task.
-#[inline(always)]
-pub unsafe fn block_current_task_with_timeout(timeout: u64) {
-	sys_block_current_task_with_timeout(timeout);
-}
-
-/// Wakeup task with the thread id `tid`
-#[inline(always)]
-pub unsafe fn wakeup_task(tid: Tid) {
-	sys_wakeup_task(tid);
 }
 
 /// Determine the priority of the current thread

--- a/hermit-sys/build.rs
+++ b/hermit-sys/build.rs
@@ -101,7 +101,7 @@ impl KernelSrc {
 		forward_features(
 			&mut cmd,
 			[
-				"acpi", "dhcpv4", "fsgsbase", "pci", "pci-ids", "smp", "tcp", "vga",
+				"acpi", "dhcpv4", "fsgsbase", "pci", "pci-ids", "smp", "tcp", "trace", "vga",
 			]
 			.into_iter(),
 		);


### PR DESCRIPTION
The new BSD socket layer depends on hermitcore/libhermit-rs#633 and a revised version of `std`. `std` is part of the [rust](/hermitcore/rust/tree/socket) fork. Note: If you use this version, please modify `Cargo.toml`.  [`hermit-abi`](https://github.com/hermitcore/rust/blob/socket/library/std/Cargo.toml#L45) must point to the version of this PR.    