### PR TITLE
Migrate from deprecated license format to SPDX License Expression

### DIFF
--- a/hermit-abi/Cargo.toml
+++ b/hermit-abi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hermit-abi"
 version = "0.2.6"
 authors = ["Stefan Lankes"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 edition = "2021"
 description = """

--- a/hermit-sys/Cargo.toml
+++ b/hermit-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hermit-sys"
 version = "0.4.0"
 authors = ["Stefan Lankes"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 description = "FFI bindings to HermitCore"
 repository = "https://github.com/hermitcore/rusty-hermit"
 readme = "README.md"


### PR DESCRIPTION
See
https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields https://spdx.dev/spdx-specification-21-web-version/#h.jxpfx0ykyb60