### PR TITLE
switch to the latest nightly compiler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
     # Manually sync this with rust-toolchain.toml!
-    RUST_VERSION=nightly-2023-02-14 \
+    RUST_VERSION=nightly-2023-04-05 \
     RUST_COMPONENTS="rust-src"
 
 RUN set -eux; \

--- a/benches/netbench/Cargo.toml
+++ b/benches/netbench/Cargo.toml
@@ -10,7 +10,7 @@ description = "A Rust program to measure bandwidth or latency over a Rust TCP co
 
 [dependencies]
 bytes = "1.1"
-clap = {verstion ="4.1", features = ["derive"] }
+clap = {version ="4.1", features = ["derive"] }
 core_affinity = "0.8"
 hdrhist = "0.5"
 

--- a/examples/demo/src/tests/thread_local.rs
+++ b/examples/demo/src/tests/thread_local.rs
@@ -1,9 +1,9 @@
 pub fn test_thread_local() -> Result<(), ()> {
-	#[repr(align(0x1000))]
-	struct OverAligned(u8);
+	#[repr(align(0x10))]
+	struct Aligned(u8);
 
 	thread_local! {
-		static THREAD_LOCAL: OverAligned = const { OverAligned(0x42) };
+		static THREAD_LOCAL: Aligned = const { Aligned(0x42) };
 	}
 
 	THREAD_LOCAL.with(|thread_local| {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # Manually sync this with Dockerfile!
-channel = "nightly-2023-03-15"
+channel = "nightly-2023-04-05"
 components = [ "rust-src" ]


### PR DESCRIPTION
- the latest std library use random `HashMap` keys rust-lang/rust#107387
- fix typo in the creation of OpenOption for RustyHermit rust-lang/rust#109368