### PR TITLE
abi: Fix & release symbol typo

### DIFF
--- a/hermit-abi/Cargo.toml
+++ b/hermit-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Stefan Lankes"]
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/hermit-abi/src/lib.rs
+++ b/hermit-abi/src/lib.rs
@@ -414,7 +414,7 @@ extern "C" {
 	pub fn unlink(name: *const i8) -> i32;
 
 	/// determines the number of activated processors
-	#[link_name = "sys_processor_count"]
+	#[link_name = "sys_get_processor_count"]
 	pub fn get_processor_count() -> usize;
 
 	#[link_name = "sys_malloc"]


### PR DESCRIPTION
`sys_processor_count` -> `sys_get_processor_count`