### PR TITLE
Include `tcp` in the default features of `hermit-sys`

### DIFF
--- a/hermit-sys/Cargo.toml
+++ b/hermit-sys/Cargo.toml
@@ -17,6 +17,7 @@ default = [
     "pci-ids",
     "smp",
     "fsgsbase",
+    "tcp",
 ]
 
 acpi = []

--- a/hermit-sys/Cargo.toml
+++ b/hermit-sys/Cargo.toml
@@ -18,6 +18,7 @@ default = [
     "smp",
     "fsgsbase",
     "tcp",
+    "dhcpv4",
 ]
 
 acpi = []


### PR DESCRIPTION
TCP is an important feature and should be part of the default features

Closes #435.