### PR TITLE
fix(hermit-abi): Fix doctest failures

### DIFF
--- a/hermit-abi/src/lib.rs
+++ b/hermit-abi/src/lib.rs
@@ -662,9 +662,10 @@ extern "C" {
 	///
 	/// # Example
 	///
-	/// ```
+	/// ```no_run
+	/// use std::ffi::CString;
 	/// use hermit_abi::in_addr;
-	/// let c_string = std::ffi::CString::new("rust-lang.org").expect("CString::new failed");
+	/// let c_string = CString::new("rust-lang.org").expect("CString::new failed");
 	/// let name = c_string.into_raw();
 	/// let mut inaddr: in_addr = Default::default();
 	/// let _ = unsafe {
@@ -676,7 +677,7 @@ extern "C" {
 	/// };
 	///
 	/// // retake pointer to free memory
-	/// let _ = CString::from_raw(name);
+	/// let _ = unsafe { CString::from_raw(name) };
 	/// ```
 	#[link_name = "sys_getaddrbyname"]
 	pub fn getaddrbyname(name: *const c_char, inaddr: *mut u8, len: usize) -> i32;
@@ -704,7 +705,7 @@ extern "C" {
 	/// action, but scatters the input data from the `iovcnt` buffers specified by the
 	/// members of the iov array: `iov[0], iov[1], ..., iov[iovcnt-1]`.
 	///
-	/// ```
+	/// ```custom
 	/// struct iovec {
 	///     char   *iov_base;  /* Base address. */
 	///     size_t iov_len;    /* Length. */
@@ -771,7 +772,7 @@ extern "C" {
 	/// action, but gathers the output data from the `iovcnt` buffers specified by the
 	/// members of the iov array: `iov[0], iov[1], ..., iov[iovcnt-1]`.
 	///
-	/// ```
+	/// ```custom
 	/// struct iovec {
 	///     char   *iov_base;  /* Base address. */
 	///     size_t iov_len;    /* Length. */


### PR DESCRIPTION
This fixes e.g.

```
running 3 tests
test hermit-abi/src/lib.rs - readv (line 708) ... ignored
test hermit-abi/src/lib.rs - writev (line 775) ... FAILED
test hermit-abi/src/lib.rs - getaddrbyname (line 665) ... FAILED

failures:

---- hermit-abi/src/lib.rs - writev (line 775) stdout ----
error: expected `:`, found `*`
 --> hermit-abi/src/lib.rs:777:12
  |
3 | struct iovec {
  |        ----- while parsing this struct
4 |     char   *iov_base;  /* Base address. */
  |            ^ expected `:`

warning: type `iovec` should have an upper camel case name
 --> hermit-abi/src/lib.rs:776:8
  |
3 | struct iovec {
  |        ^^^^^ help: convert the identifier to upper camel case (notice the capitalization): `Iovec`
  |
  = note: `#[warn(non_camel_case_types)]` (part of `#[warn(nonstandard_style)]`) on by default

error: aborting due to 1 previous error; 1 warning emitted

Couldn't compile the test.
---- hermit-abi/src/lib.rs - getaddrbyname (line 665) stdout ----
error[E0133]: call to unsafe function `CString::from_raw` is unsafe and requires unsafe function or block
  --> hermit-abi/src/lib.rs:681:9
   |
19 | let _ = CString::from_raw(name);
   |         ^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
   |
   = note: consult the function's documentation for information on how to avoid undefined behavior

error: aborting due to 1 previous error

For more information about this error, try `rustc --explain E0133`.
Couldn't compile the test.

failures:
    hermit-abi/src/lib.rs - getaddrbyname (line 665)
    hermit-abi/src/lib.rs - writev (line 775)
```

and similar errors.