### PR TITLE
feat(hermit): add and forward semihosting feature

### DIFF
--- a/hermit/Cargo.toml
+++ b/hermit/Cargo.toml
@@ -61,6 +61,7 @@ randomize-layout = []
 # if this feature isn't set, the Virtio interface will be used
 rtl8139 = ["pci"]
 
+semihosting = []
 shell = []
 smp = []
 strace = []

--- a/hermit/build.rs
+++ b/hermit/build.rs
@@ -142,6 +142,7 @@ impl KernelSrc {
 				"pci",
 				"pci-ids",
 				"rtl8139",
+				"semihosting",
 				"shell",
 				"smp",
 				"strace",


### PR DESCRIPTION
This has been available since https://github.com/hermit-os/kernel/pull/1040.