### PR TITLE
feat(axum-example): add variable length endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,7 @@ version = "0.0.0"
 dependencies = [
  "axum",
  "hermit",
+ "serde",
  "tokio",
 ]
 

--- a/examples/axum/Cargo.toml
+++ b/examples/axum/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 [dependencies]
 axum = "0.8"
 tokio = "1"
+serde = { version = "1", features = ["derive"] }
 
 [target.'cfg(target_os = "hermit")'.dependencies]
 hermit = { path = "../../hermit" }

--- a/examples/axum/src/main.rs
+++ b/examples/axum/src/main.rs
@@ -1,14 +1,20 @@
+use std::fmt::Write as _;
+
+use axum::extract::Query;
 use axum::routing::get;
 use axum::Router;
 #[cfg(target_os = "hermit")]
 use hermit as _;
+use serde::Deserialize;
 use tokio::{io, net};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> io::Result<()> {
 	println!("Testing axum...");
 
-	let app = Router::new().route("/", get(root));
+	let app = Router::new()
+		.route("/", get(root))
+		.route("/bytes", get(bytes));
 
 	let listener = net::TcpListener::bind("0.0.0.0:9975").await?;
 	axum::serve(listener, app).await?;
@@ -18,4 +24,40 @@ async fn main() -> io::Result<()> {
 
 async fn root() -> &'static str {
 	"Hello, world!\n"
+}
+
+#[derive(Deserialize)]
+struct Bytes {
+	len: usize,
+}
+
+async fn bytes(Query(Bytes { len }): Query<Bytes>) -> String {
+	const SEPARATOR: &str = ", ";
+	const USIZE_BITS: usize = usize::BITS as usize;
+	const BITS_PER_HEX_DIGIT: usize = 4;
+
+	let mut s = String::with_capacity(len);
+	let mut buffer = String::with_capacity(SEPARATOR.len() + (USIZE_BITS / BITS_PER_HEX_DIGIT));
+	let mut range = 0usize..;
+	let mut remaining_len;
+
+	loop {
+		let i = range.next().unwrap();
+		if i != 0 {
+			buffer.push_str(SEPARATOR);
+		}
+		write!(&mut buffer, "{i:x}").unwrap();
+		remaining_len = s.capacity() - s.len();
+
+		if remaining_len <= buffer.len() {
+			break;
+		}
+
+		s.extend(buffer.drain(..));
+	}
+
+	s.push_str(&"x".repeat(remaining_len - 1));
+	s.push('X');
+
+	s
 }


### PR DESCRIPTION
The segmentation offload driver feature can only be tested with sufficiently large packets. Add a new endpoint whose response size can be adjusted easily and that can be visually inspected for correctness.