### PR TITLE
refactor(build.rs): don't hardcode features

### DIFF
--- a/hermit/Cargo.toml
+++ b/hermit/Cargo.toml
@@ -82,11 +82,6 @@ nostd = []
 trace = []
 vsock = []
 
-#! ### Deprecated Features
-
-instrument = ["instrument-mcount"]
-log-target = []
-
 [build-dependencies]
 cc = "1"
 home = "0.5"

--- a/hermit/Cargo.toml
+++ b/hermit/Cargo.toml
@@ -24,12 +24,12 @@ talc = { version = "4.4", default-features = false, features = ["lock_api"], opt
 [features]
 default = []
 common-os = [
-	"hermit-abi",
-	"generic_once_cell",
-	"libm",
-	"spinning_top",
-	"take-static",
-	"talc",
+	"dep:hermit-abi",
+	"dep:generic_once_cell",
+	"dep:libm",
+	"dep:spinning_top",
+	"dep:take-static",
+	"dep:talc",
 ]
 
 ## Links against libc.a.

--- a/hermit/Cargo.toml
+++ b/hermit/Cargo.toml
@@ -2,8 +2,8 @@
 name = "hermit"
 version = "0.13.2"
 authors = [
-    "Stefan Lankes <slankes@eonerc.rwth-aachen.de>",
-    "Martin Kröning <mkroening@posteo.net>",
+	"Stefan Lankes <slankes@eonerc.rwth-aachen.de>",
+	"Martin Kröning <mkroening@posteo.net>",
 ]
 edition = "2021"
 description = "The Hermit unikernel for Rust."
@@ -19,11 +19,18 @@ generic_once_cell = { version = "0.1", optional = true }
 libm = { version = "0.2", optional = true }
 spinning_top = { version = "0.3", optional = true }
 take-static = { version = "0.1", optional = true }
-talc = { version = "4.4", default-features = false, features = ["lock_api"], optional = true  }
+talc = { version = "4.4", default-features = false, features = ["lock_api"], optional = true }
 
 [features]
 default = []
-common-os = ["hermit-abi", "generic_once_cell", "libm", "spinning_top", "take-static", "talc"]
+common-os = [
+	"hermit-abi",
+	"generic_once_cell",
+	"libm",
+	"spinning_top",
+	"take-static",
+	"talc",
+]
 
 ## Links against libc.a.
 libc = []

--- a/hermit/build.rs
+++ b/hermit/build.rs
@@ -95,56 +95,7 @@ impl KernelSrc {
 			.arg("--target-dir")
 			.arg(&target_dir);
 
-		// Control enabled features via this crate's features
-		cargo.arg("--no-default-features");
-		forward_features(
-			&mut cargo,
-			[
-				"default",
-				"common-os",
-				"mman",
-				"newlib",
-				"uhyve",
-				"acpi",
-				"fsgsbase",
-				"pci",
-				"pci-ids",
-				"semihosting",
-				"smp",
-				"tcp",
-				"udp",
-				"dhcpv4",
-				"dns",
-				"net-trace",
-				"write-pcap-file",
-				"virtio-net",
-				"rtl8139",
-				"gem-net",
-				"virtio-console",
-				"virtio-fs",
-				"virtio-vsock",
-				"vga",
-				"idle-poll",
-				"alloc-stats",
-				"instrument-mcount",
-				"kernel-stack",
-				"randomize-layout",
-				"shell",
-				"strace",
-				"document-features",
-				"net",
-				"virtio",
-				"warn-prebuilt",
-				"console",
-				"fs",
-				"fuse",
-				"mmap",
-				"nostd",
-				"trace",
-				"vsock",
-			]
-			.into_iter(),
-		);
+		forward_features(&mut cargo);
 
 		println!("cargo:warning=$ {cargo:?}");
 		let status = cargo.status().expect("failed to start kernel build");
@@ -264,9 +215,16 @@ fn has_feature(feature: &str) -> bool {
 	env::var_os(&var).is_some()
 }
 
-fn forward_features<'a>(cmd: &mut Command, features: impl Iterator<Item = &'a str>) {
-	let features = features.filter(|f| has_feature(f)).collect::<Vec<_>>();
-	if !features.is_empty() {
-		cmd.args(["--features", &features.join(" ")]);
-	}
+/// Forward Cargo features to kernel build.
+fn forward_features(cargo: &mut Command) {
+	cargo.arg("--no-default-features");
+
+	let cargo_cfg_feature = env::var("CARGO_CFG_FEATURE").unwrap();
+	let cargo_cfg_feature = cargo_cfg_feature
+		.split(',')
+		.filter(|feature| *feature != "libc")
+		.collect::<Vec<_>>();
+	let cargo_cfg_feature = cargo_cfg_feature.join(",");
+
+	cargo.arg("--features").arg(cargo_cfg_feature);
 }


### PR DESCRIPTION
This PR avoids hardcoding the kernel features in `build.rs`.
`CARGO_CFG_FEATURE` exists as of Rust 1.85 and provides all enabled features.
We still need to hardcode them in the wrapper crate's Cargo.toml, since we cannot dynamically populate the features.

Depends on https://github.com/hermit-os/hermit-rs/pull/990.
Depends on https://github.com/hermit-os/hermit-rs/pull/989.