### PR TITLE
fix(benches/alloc): Fix panics during measurement recording by prealloc + iteration count cap

### DIFF
--- a/benches/alloc/src/main.rs
+++ b/benches/alloc/src/main.rs
@@ -77,11 +77,10 @@ fn benchmark_allocator() -> BenchRunResults {
 
 	fastrand::seed(0x55a72645d29afb98);
 
-	let mut active_allocations = Vec::new();
-
-	let mut all_alloc_measurements = Vec::new();
-	let mut nofail_alloc_measurements = Vec::new();
-	let mut dealloc_measurements = Vec::new();
+	let mut active_allocations = Vec::with_capacity(MAX_ALLOCATIONS);
+	let mut all_alloc_measurements = Vec::with_capacity(MAX_ALLOCATIONS);
+	let mut nofail_alloc_measurements = Vec::with_capacity(MAX_ALLOCATIONS);
+	let mut dealloc_measurements = Vec::with_capacity(MAX_ALLOCATIONS);
 
 	let mut allocation_attempts = 0;
 	let mut successful_allocations = 0;

--- a/benches/alloc/src/main.rs
+++ b/benches/alloc/src/main.rs
@@ -30,13 +30,12 @@ SOFTWARE.
  */
 
 use std::alloc::{alloc, dealloc, Layout};
-use std::time::Instant;
 
 #[cfg(target_os = "hermit")]
 use hermit as _;
 use hermit_bench_output::log_benchmark_data;
 
-const BENCH_DURATION: f64 = 2.0;
+const MAX_ALLOCATIONS: usize = 0x20_0000;
 
 fn main() {
 	let bench_alloc = benchmark_allocator();
@@ -91,9 +90,7 @@ fn benchmark_allocator() -> BenchRunResults {
 
 	let mut any_alloc_failed = false;
 
-	// run for 10s
-	let bench_begin_time = Instant::now();
-	while bench_begin_time.elapsed().as_secs_f64() <= BENCH_DURATION {
+	while all_alloc_measurements.len() < MAX_ALLOCATIONS {
 		let size = fastrand::usize((1 << 6)..(1 << 15));
 		let align = 8 << (fastrand::u16(..).trailing_zeros() / 2);
 		let layout = Layout::from_size_align(size, align).unwrap();


### PR DESCRIPTION
This PR does the following to the alloc benchmark:
* Limits the iteration count of the main loop instead of using a timecap
* Preallocate measurements to avoid OOM panics (because otherwise `..._measurements.push(...);` can panic)

Fixes https://github.com/hermit-os/hermit-rs/issues/873.