### PR TITLE
feat: add kernel log compile-time filters

### DIFF
--- a/hermit/Cargo.toml
+++ b/hermit/Cargo.toml
@@ -35,6 +35,25 @@ common-os = [
 ## Links against libc.a.
 libc = []
 
+#! ### Logging Features
+#!
+#! Enables the corresponding feature for the kernel's `log` crate.
+#!
+#! For details, see [log compile time filters](https://docs.rs/log/0.4.33/log/#compile-time-filters).
+
+log-max_level_off = []
+log-max_level_error = []
+log-max_level_warn = []
+log-max_level_info = []
+log-max_level_debug = []
+log-max_level_trace = []
+log-release_max_level_off = []
+log-release_max_level_error = []
+log-release_max_level_warn = []
+log-release_max_level_info = []
+log-release_max_level_debug = []
+log-release_max_level_trace = []
+
 #! ### Kernel Features
 #!
 #! For details, see the kernel [docs].

--- a/hermit/build.rs
+++ b/hermit/build.rs
@@ -222,6 +222,13 @@ fn forward_features(cargo: &mut Command) {
 	let cargo_cfg_feature = env::var("CARGO_CFG_FEATURE").unwrap();
 	let cargo_cfg_feature = cargo_cfg_feature
 		.split(',')
+		.map(|feature| {
+			if let Some(log_feature) = feature.strip_prefix("log-") {
+				["log/", log_feature].join("")
+			} else {
+				feature.to_owned()
+			}
+		})
 		.filter(|feature| *feature != "libc")
 		.collect::<Vec<_>>();
 	let cargo_cfg_feature = cargo_cfg_feature.join(",");


### PR DESCRIPTION
This PR adds support for configuring the kernel logging's compile-time filters. For example, all kernel logging can be statically disabled with `--features hermit/log-max_level_off`.

For details, see [log compile time filters](https://docs.rs/log/0.4.33/log/#compile-time-filters).

On the `release` profile, disabling all kernel logging affects the image sizes as follows:

| Max Level | `hello_world` | `axum-example` |
| --------- | -------------:| --------------:|
| all       |        845880 |        5702224 |
| trace     |        845928 |        5700592 |
| debug     |        828808 |        5660664 |
| info      |        798120 |        5591992 |
| warn      |        764888 |        2145008 |
| error     |        759664 |        2064528 |
| off       |        737016 |        2078352 |


The big difference from info to warn on Axum is due to the elision of the PCI-IDs database in the kernel.